### PR TITLE
[BOT] Bump bashunit to version 0.24.0

### DIFF
--- a/lib/bashunit
+++ b/lib/bashunit
@@ -197,7 +197,11 @@ function temp_file() {
   mkdir -p "$base_dir" && chmod -R 777 "$base_dir"
   local test_prefix=""
   if [[ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]]; then
+    # We're inside a test function - use test ID
     test_prefix="${BASHUNIT_CURRENT_TEST_ID}_"
+  elif [[ -n "${BASHUNIT_CURRENT_SCRIPT_ID:-}" ]]; then
+    # We're at script level (e.g., in set_up_before_script) - use script ID
+    test_prefix="${BASHUNIT_CURRENT_SCRIPT_ID}_"
   fi
   mktemp "$base_dir/${test_prefix}${prefix}.XXXXXXX"
 }
@@ -208,17 +212,26 @@ function temp_dir() {
   mkdir -p "$base_dir" && chmod -R 777 "$base_dir"
   local test_prefix=""
   if [[ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]]; then
+    # We're inside a test function - use test ID
     test_prefix="${BASHUNIT_CURRENT_TEST_ID}_"
+  elif [[ -n "${BASHUNIT_CURRENT_SCRIPT_ID:-}" ]]; then
+    # We're at script level (e.g., in set_up_before_script) - use script ID
+    test_prefix="${BASHUNIT_CURRENT_SCRIPT_ID}_"
   fi
   mktemp -d "$base_dir/${test_prefix}${prefix}.XXXXXXX"
 }
 
-function cleanup_temp_files() {
-  internal_log "cleanup_temp_files"
+function cleanup_testcase_temp_files() {
+  internal_log "cleanup_testcase_temp_files"
   if [[ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]]; then
     rm -rf "${TMPDIR:-/tmp}/bashunit/tmp/${BASHUNIT_CURRENT_TEST_ID}"_*
-  else
-    rm -rf "${TMPDIR:-/tmp}/bashunit/tmp"/*
+  fi
+}
+
+function cleanup_script_temp_files() {
+  internal_log "cleanup_script_temp_files"
+  if [[ -n "${BASHUNIT_CURRENT_SCRIPT_ID:-}" ]]; then
+    rm -rf "${TMPDIR:-/tmp}/bashunit/tmp/${BASHUNIT_CURRENT_SCRIPT_ID}"_*
   fi
 }
 
@@ -255,6 +268,21 @@ function print_line() {
   local length="${1:-70}"   # Default to 70 if not passed
   local char="${2:--}"      # Default to '-' if not passed
   printf '%*s\n' "$length" '' | tr ' ' "$char"
+}
+
+function data_set() {
+  local arg
+  local first=true
+
+  for arg in "$@"; do
+    if [ "$first" = true ]; then
+      printf '%q' "$arg"
+      first=false
+    else
+      printf ' %q' "$arg"
+    fi
+  done
+  printf '\n'
 }
 
 # dependencies.sh
@@ -443,11 +471,14 @@ function parallel::must_stop_on_failure() {
   [[ -f "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE" ]]
 }
 
-function parallel::reset() {
+function parallel::cleanup() {
   # shellcheck disable=SC2153
   rm -rf "$TEMP_DIR_PARALLEL_TEST_SUITE"
+}
+
+function parallel::init() {
+  parallel::cleanup
   mkdir -p "$TEMP_DIR_PARALLEL_TEST_SUITE"
-  [ -f "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE" ] && rm "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE"
 }
 
 function parallel::is_enabled() {
@@ -1073,7 +1104,7 @@ function console_header::print_version() {
   if [[ ${#files[@]} -eq 0 ]]; then
     total_tests=0
   else
-    total_tests=$(helpers::find_total_tests "$filter" "${files[@]}")
+    total_tests=$(helper::find_total_tests "$filter" "${files[@]}")
   fi
 
   if env::is_header_ascii_art_enabled; then
@@ -1297,7 +1328,15 @@ function console_results::print_successful_test() {
   if [[ -z "$*" ]]; then
     line=$(printf "%s✓ Passed%s: %s" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "$test_name")
   else
-    line=$(printf "%s✓ Passed%s: %s (%s)" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "$test_name" "$*")
+    local quoted_args=""
+    for arg in "$@"; do
+      if [[ -z "$quoted_args" ]]; then
+        quoted_args="'$arg'"
+      else
+        quoted_args="$quoted_args, '$arg'"
+      fi
+    done
+    line=$(printf "%s✓ Passed%s: %s (%s)" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "$test_name" "$quoted_args")
   fi
 
   local full_line=$line
@@ -1510,6 +1549,16 @@ function helper::interpolate_function_name() {
   echo "$result"
 }
 
+function helper::encode_base64() {
+  local value="$1"
+
+  if command -v base64 >/dev/null; then
+    echo "$value" | base64 | tr -d '\n'
+  else
+    echo "$value" | openssl enc -base64 -A
+  fi
+}
+
 function helper::decode_base64() {
   local value="$1"
 
@@ -1659,7 +1708,7 @@ function helper::trim() {
   echo "$trimmed_string"
 }
 
-function helpers::get_latest_tag() {
+function helper::get_latest_tag() {
   if ! dependencies::has_git; then
     return 1
   fi
@@ -1671,7 +1720,7 @@ function helpers::get_latest_tag() {
     head -n 1
 }
 
-function helpers::find_total_tests() {
+function helper::find_total_tests() {
     local filter=${1:-}
     local files=("${@:2}")
 
@@ -1778,13 +1827,24 @@ function helper::get_function_line_number() {
   echo "$line_number"
 }
 
+function helper::generate_id() {
+  local basename="$1"
+  local sanitized_basename
+  sanitized_basename="$(helper::normalize_variable_name "$basename")"
+  if env::is_parallel_run_enabled; then
+    echo "${sanitized_basename}_$$_$(random_str 6)"
+  else
+    echo "${sanitized_basename}_$$"
+  fi
+}
+
 # upgrade.sh
 
 function upgrade::upgrade() {
   local script_path
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local latest_tag
-  latest_tag="$(helpers::get_latest_tag)"
+  latest_tag="$(helper::get_latest_tag)"
 
   if [[ "$BASHUNIT_VERSION" == "$latest_tag" ]]; then
     echo "> You are already on latest version"
@@ -2811,7 +2871,14 @@ function spy() {
   export "${variable}_params_file"="$params_file"
 
   eval "function $command() {
-    echo \"\$*\" >> '$params_file'
+    local raw=\"\$*\"
+    local serialized=\"\"
+    local arg
+    for arg in \"\$@\"; do
+      serialized+=\"\$(printf '%q' \"\$arg\")$'\\x1f'\"
+    done
+    serialized=\${serialized%$'\\x1f'}
+    printf '%s|%s\\n' \"\$raw\" \"\$serialized\" >> '$params_file'
     local _c=\$(cat '$times_file')
     _c=\$((_c+1))
     echo \"\$_c\" > '$times_file'
@@ -2843,36 +2910,36 @@ function assert_have_been_called() {
 }
 
 function assert_have_been_called_with() {
-  local expected=$1
-  local command=$2
-  local third_arg="${3:-}"
-  local fourth_arg="${4:-}"
+  local command=$1
+  shift
 
   local index=""
-  local label=""
-  if [[ -n $third_arg && $third_arg =~ ^[0-9]+$ ]]; then
-    index=$third_arg
-    label="${fourth_arg:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
-  else
-    label="${third_arg:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
-    index="$fourth_arg"
+  if [[ ${!#} =~ ^[0-9]+$ ]]; then
+    index=${!#}
+    set -- "${@:1:$#-1}"
   fi
+
+  local expected="$*"
 
   local variable
   variable="$(helper::normalize_variable_name "$command")"
   local file_var="${variable}_params_file"
-  local params=""
+  local line=""
   if [[ -f "${!file_var-}" ]]; then
     if [[ -n $index ]]; then
-      params=$(sed -n "${index}p" "${!file_var}")
+      line=$(sed -n "${index}p" "${!file_var}")
     else
-      params=$(tail -n 1 "${!file_var}")
+      line=$(tail -n 1 "${!file_var}")
     fi
   fi
 
-  if [[ "$expected" != "$params" ]]; then
+  local raw
+  IFS='|' read -r raw _ <<<"$line"
+
+  if [[ "$expected" != "$raw" ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${expected}" "but got " "$params"
+    console_results::print_failed_test "$(helper::normalize_test_function_name \
+      "${FUNCNAME[1]}")" "$expected" "but got " "$raw"
     return
   fi
 
@@ -2880,7 +2947,7 @@ function assert_have_been_called_with() {
 }
 
 function assert_have_been_called_times() {
-  local expected=$1
+  local expected_count=$1
   local command=$2
   local variable
   variable="$(helper::normalize_variable_name "$command")"
@@ -2890,10 +2957,10 @@ function assert_have_been_called_times() {
     times=$(cat "${!file_var}")
   fi
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
-  if [[ $times -ne $expected ]]; then
+  if [[ $times -ne $expected_count ]]; then
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${command}" \
-      "to have been called" "${expected} times" \
+      "to have been called" "${expected_count} times" \
       "actual" "${times} times"
     return
   fi
@@ -3111,11 +3178,15 @@ function runner::load_test_files() {
   local filter=$1
   shift
   local files=("${@}")
+  local scripts_ids=()
 
   for test_file in "${files[@]}"; do
     if [[ ! -f $test_file ]]; then
       continue
     fi
+    unset BASHUNIT_CURRENT_TEST_ID
+    export BASHUNIT_CURRENT_SCRIPT_ID="$(helper::generate_id "${test_file}")"
+    scripts_ids+=("${BASHUNIT_CURRENT_SCRIPT_ID}")
     internal_log "Loading file" "$test_file"
     # shellcheck source=/dev/null
     source "$test_file"
@@ -3127,6 +3198,9 @@ function runner::load_test_files() {
     fi
     runner::run_tear_down_after_script
     runner::clean_set_up_and_tear_down_after_script
+    if ! parallel::is_enabled; then
+      cleanup_script_temp_files
+    fi
     internal_log "Finished file" "$test_file"
   done
 
@@ -3138,6 +3212,10 @@ function runner::load_test_files() {
     # Kill the spinner once the aggregation finishes
     disown "$spinner_pid" && kill "$spinner_pid" &>/dev/null
     printf "\r " # Clear the spinner output
+    for script_id in "${scripts_ids[@]}"; do
+      export BASHUNIT_CURRENT_SCRIPT_ID="${script_id}"
+      cleanup_script_temp_files
+    done
   fi
 }
 
@@ -3148,12 +3226,15 @@ function runner::load_bench_files() {
 
   for bench_file in "${files[@]}"; do
     [[ -f $bench_file ]] || continue
+    unset BASHUNIT_CURRENT_TEST_ID
+    export BASHUNIT_CURRENT_SCRIPT_ID="$(helper::generate_id "${test_file}")"
     # shellcheck source=/dev/null
     source "$bench_file"
     runner::run_set_up_before_script
     runner::call_bench_functions "$bench_file" "$filter"
     runner::run_tear_down_after_script
     runner::clean_set_up_and_tear_down_after_script
+    cleanup_script_temp_files
   done
 }
 
@@ -3184,6 +3265,68 @@ function runner::functions_for_script() {
     sort -k2 -n |
     awk '{print $1}'
   shopt -u extdebug
+}
+
+function runner::parse_data_provider_args() {
+  local input="$1"
+  local current_arg=""
+  local in_quotes=false
+  local quote_char=""
+  local escaped=false
+  local i
+  local arg
+  local encoded_arg
+  local -a args=()
+  # Parse args from the input string into an array, respecting quotes and escapes
+  for ((i=0; i<${#input}; i++)); do
+    local char="${input:$i:1}"
+    if [ "$escaped" = true ]; then
+      case "$char" in
+        t) current_arg+=$'\t' ;;
+        n) current_arg+=$'\n' ;;
+        *) current_arg+="$char" ;;
+      esac
+      escaped=false
+    elif [ "$char" = "\\" ]; then
+      escaped=true
+    elif [ "$in_quotes" = false ]; then
+      case "$char" in
+        "$")
+          # Handle $'...' syntax
+          if [[ "${input:$i:2}" == "$'" ]]; then
+            in_quotes=true
+            quote_char="'"
+            # Skip the $
+            i=$((i + 1))
+          else
+            current_arg+="$char"
+          fi
+          ;;
+        "'" | '"')
+          in_quotes=true
+          quote_char="$char"
+          ;;
+        " " | $'\t')
+          args+=("$current_arg")
+          current_arg=""
+          ;;
+        *)
+          current_arg+="$char"
+          ;;
+      esac
+    elif [ "$char" = "$quote_char" ]; then
+      in_quotes=false
+      quote_char=""
+    else
+      current_arg+="$char"
+    fi
+  done
+  args+=("$current_arg")
+  # Print one arg per line to stdout, base64-encoded to preserve newlines in the data
+  for arg in "${args[@]}"; do
+    encoded_arg="$(helper::encode_base64 "${arg}")"
+    printf '%s\n' "$encoded_arg"
+  done
 }
 
 function runner::call_test_functions() {
@@ -3222,12 +3365,11 @@ function runner::call_test_functions() {
 
     # Execute the test function for each line of data
     for data in "${provider_data[@]}"; do
-      IFS=" " read -r -a args <<< "$data"
-      if [ "${#args[@]}" -gt 1 ]; then
-        runner::run_test "$script" "$fn_name" "${args[@]}"
-      else
-        runner::run_test "$script" "$fn_name" "$data"
-      fi
+      local parsed_data=()
+      while IFS= read -r line; do
+        parsed_data+=( "$(helper::decode_base64 "${line}")" )
+      done <<< "$(runner::parse_data_provider_args "$data")"
+      runner::run_test "$script" "$fn_name" "${parsed_data[@]}"
     done
     unset fn_name
   done
@@ -3295,17 +3437,11 @@ function runner::run_test() {
   local fn_name="$1"
   shift
 
+  internal_log "Running test" "$fn_name" "$*"
   # Export a unique test identifier so that test doubles can
   # create temporary files scoped per test run. This prevents
   # race conditions when running tests in parallel.
-  local sanitized_fn_name
-  sanitized_fn_name="$(helper::normalize_variable_name "$fn_name")"
-  internal_log "Running test" "$fn_name" "$*"
-  if env::is_parallel_run_enabled; then
-    export BASHUNIT_CURRENT_TEST_ID="${sanitized_fn_name}_$$_$(random_str 6)"
-  else
-    export BASHUNIT_CURRENT_TEST_ID="${sanitized_fn_name}_$$"
-  fi
+  export BASHUNIT_CURRENT_TEST_ID="$(helper::generate_id "$fn_name")"
 
   state::reset_test_title
 
@@ -3328,6 +3464,7 @@ function runner::run_test() {
       state::set_test_exit_code "$exit_code"
       runner::run_tear_down
       runner::clear_mocks
+      cleanup_testcase_temp_files
       state::export_subshell_context
     ' EXIT
     state::initialize_assertions_count
@@ -3726,7 +3863,7 @@ function main::exec_tests() {
   fi
 
   if parallel::is_enabled; then
-    parallel::reset
+    parallel::init
   fi
 
   console_header::print_version_with_env "$filter" "${test_files[@]}"
@@ -3767,7 +3904,10 @@ function main::exec_tests() {
     reports::generate_report_html "$BASHUNIT_REPORT_HTML"
   fi
 
-  cleanup_temp_files
+  if parallel::is_enabled; then
+    parallel::cleanup
+  fi
+
   internal_log "Finished tests" "exit_code:$exit_code"
   exit $exit_code
 }
@@ -3795,7 +3935,6 @@ function main::exec_benchmarks() {
 
   benchmark::print_results
 
-  cleanup_temp_files
   internal_log "Finished benchmarks"
 }
 
@@ -3803,7 +3942,10 @@ function main::cleanup() {
   printf "%sCaught Ctrl-C, killing all child processes...%s\n"  "${_COLOR_SKIPPED}" "${_COLOR_DEFAULT}"
   # Kill all child processes of this script
   pkill -P $$
-  cleanup_temp_files
+  cleanup_script_temp_files
+  if parallel::is_enabled; then
+    parallel::cleanup
+  fi
   exit 1
 }
 
@@ -3811,7 +3953,10 @@ function main::handle_stop_on_failure_sync() {
   printf "\n%sStop on failure enabled...%s\n"  "${_COLOR_SKIPPED}" "${_COLOR_DEFAULT}"
   console_results::print_failing_tests_and_reset
   console_results::render_result
-  cleanup_temp_files
+  cleanup_script_temp_files
+  if parallel::is_enabled; then
+    parallel::cleanup
+  fi
   exit 1
 }
 
@@ -3921,7 +4066,7 @@ function _check_bash_version() {
 _check_bash_version
 
 # shellcheck disable=SC2034
-declare -r BASHUNIT_VERSION="0.23.0"
+declare -r BASHUNIT_VERSION="0.24.0"
 
 # shellcheck disable=SC2155
 declare -r BASHUNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
Update bashunit to version [0.24.0](https://github.com/TypedDevs/bashunit/releases/tag/0.24.0).

<details>
  <summary>Release Notes:</summary>

  # What's changed

> TL;DR: Improved argument matching in assertions, clearer docs, and multiple bug fixes for data providers and temp cleanup.

## ✨ Improvements

- Improve `assert_have_been_called_with` arg matching #474
- Rename helper functions to helper prefix #475

## 📖 Documentation

- Make Windows install clearer #477
- Workaround docs for global name collisions #481

## 🐛 Bug Fixes

- Fix support for whitespace in data providers #479
- Always correctly clean up temp contents #483
- Clean parallel temp folder after test run #484
- Fix support for tabs in data set values #485
- Fix support for newlines in data providers #487

## 👥 Contributors

@Chemaclass @antonio-gg-dev @CosmeValera @carlfriedrich

## 🆕 New Contributors

- @carlfriedrich made their first contribution in #479

**Full Changelog**: https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0
</details>