### PR TITLE
ci: install bashunit via official action and harden update bot

### DIFF
--- a/.github/workflows/bashunit-update.yml
+++ b/.github/workflows/bashunit-update.yml
@@ -57,12 +57,25 @@ jobs:
           LOCAL_FILE="lib/bashunit"
           TEMP_FILE="/tmp/bashunit"
 
-          # Download the file
-          curl -L -o $TEMP_FILE $DOWNLOAD_URL
+          # Download the file. -f fails on HTTP errors (e.g. 504), so a gateway
+          # error page is never written as a "successful" download. Retry to
+          # ride out transient hiccups.
+          curl -fSL --retry 3 --retry-delay 5 -o "$TEMP_FILE" "$DOWNLOAD_URL"
 
-          # Check if the file was downloaded successfully
-          if [ ! -s $TEMP_FILE ]; then
-            echo "Download failed. Exiting."
+          # Validate the download is actually a bashunit script, not an HTML
+          # error page that slipped through. Check the shebang and smoke-test it.
+          if [ ! -s "$TEMP_FILE" ]; then
+            echo "Download failed: empty file. Exiting."
+            exit 1
+          fi
+          if ! head -1 "$TEMP_FILE" | grep -q '^#!'; then
+            echo "Download failed: not a script (no shebang). First lines:"
+            head -3 "$TEMP_FILE"
+            exit 1
+          fi
+          chmod +x "$TEMP_FILE"
+          if ! "$TEMP_FILE" --version >/dev/null 2>&1; then
+            echo "Download failed: binary does not run. Exiting."
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set permissions
-        run: chmod +x ./lib/bashunit
+      - name: Install bashunit
+        uses: TypedDevs/bashunit@latest
 
       - name: Run build tests
         working-directory: ./tests
-        run: ../lib/bashunit ./unit/workflows/build
+        run: bashunit ./unit/workflows/build
 
       - name: Run synversion tests
         working-directory: ./tests
-        run: ../lib/bashunit ./unit/workflows/syncversion
+        run: bashunit ./unit/workflows/syncversion
 
   test-snycversion-workflow:
     needs: test-scripts


### PR DESCRIPTION
## Why

#82 committed a 504 HTML page as `lib/bashunit` and broke CI. The update bot only checked the download was non-empty, so the error page slipped through.

## What

- **`test.yml`**: install bashunit via `TypedDevs/bashunit@latest` (checksum-verified) instead of running the vendored binary. CI no longer breaks on a bad download.
- **`bashunit-update.yml`**: `curl -fSL --retry` + shebang/`--version` checks before committing, so the bot can't open a junk PR again.

`lib/bashunit` kept for local/docker dev. Closes #82.