### PR TITLE
Fix workflow-run limits for forks

### DIFF
--- a/.github/workflows/_shared-build.yml
+++ b/.github/workflows/_shared-build.yml
@@ -45,7 +45,8 @@ on:
 env:
   DOCKER_REGISTRY: docker.io
   GITHUB_REGISTRY: ghcr.io
-  DOCKER_IMAGE:  docker.io/${{ vars.DOCKERHUB_USERNAME }}/gitlab
+  DOCKERHUB_USERNAME: feskol
+  DOCKER_IMAGE:  docker.io/feskol/gitlab
   GITHUB_IMAGE: ghcr.io/${{ github.repository_owner }}/gitlab
 
 jobs:
@@ -124,7 +125,7 @@ jobs:
         if: inputs.is_test == false
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ vars.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker login GitHubs container registry
@@ -175,7 +176,7 @@ jobs:
         run: |
           if [[ "${{ matrix.platform }}" == "DOCKERHUB" ]]; then
             echo "REGISTRY=${{ env.DOCKER_REGISTRY }}" >> $GITHUB_ENV
-            echo "USERNAME=${{ vars.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+            echo "USERNAME=${{ env.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
             echo "PASSWORD=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
             echo "MANIFEST_TAGS=${{ needs.validate-and-prepare.outputs.dockerhub_manifest_tags }}" >> $GITHUB_ENV
             echo "ARM64_IMAGE_TAG=${{ needs.validate-and-prepare.outputs.dockerhub_arm64_image_tag }}" >> $GITHUB_ENV
@@ -202,7 +203,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ vars.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: GitHub Container Registry manifest fix 2/3 (Download official GitLab docker image for amd64)

--- a/.github/workflows/_shared-syncversion.yml
+++ b/.github/workflows/_shared-syncversion.yml
@@ -101,7 +101,9 @@ jobs:
         # GITHUB_ENV: NEW_BUILD_EE_VERSION_AVAILABLE
 
       - name: Trigger builds for new versions
-        if: ${{ env.NEW_BUILD_CE_VERSION_AVAILABLE == 'true' || env.NEW_BUILD_EE_VERSION_AVAILABLE == 'true' }}
+        if: |
+          github.repository == 'feskol/gitlab-arm64' &&
+          (env.NEW_BUILD_CE_VERSION_AVAILABLE == 'true' || env.NEW_BUILD_EE_VERSION_AVAILABLE == 'true')
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Description
When a pull request comes from a fork, GitHub intentionally restricts the GITHUB_TOKEN to read-only access. This is a security boundary — a fork cannot write to, trigger workflows on, or push to the upstream repository. Without guards, the test workflow would crash with 403 errors on any step that tries to do so.
