### PR TITLE
[BOT] Bump bashunit to version 0.42.0

### DIFF
--- a/lib/bashunit
+++ b/lib/bashunit
@@ -41,8 +41,6 @@ function bashunit::check_os::is_nixos() {
   grep -q '^ID=nixos' /etc/os-release 2>/dev/null
 }
 
-_BASHUNIT_UNAME="$(uname)"
-
 function bashunit::check_os::is_linux() {
   [ "$_BASHUNIT_UNAME" = "Linux" ]
 }
@@ -62,6 +60,30 @@ function bashunit::check_os::is_windows() {
   esac
 }
 
+##
+# Detects the number of online CPU cores, portably across Linux/macOS/BSD.
+# Tries nproc, then sysctl, then getconf; falls back to 4 when none report a
+# usable positive integer. Takes the first whitespace-delimited token so a
+# stray flag or trailing text never poisons the arithmetic guard.
+# Returns: prints the core count (>= 1) to stdout.
+##
+function bashunit::check_os::nproc() {
+  local cores=""
+  cores="$(nproc 2>/dev/null)" || cores=""
+  if [ -z "$cores" ]; then
+    cores="$(sysctl -n hw.ncpu 2>/dev/null)" || cores=""
+  fi
+  if [ -z "$cores" ]; then
+    cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null)" || cores=""
+  fi
+  cores="${cores%% *}"
+  case "$cores" in
+  '' | *[!0-9]*) cores=4 ;;
+  esac
+  [ "$cores" -lt 1 ] && cores=4
+  echo "$cores"
+}
+
 function bashunit::check_os::is_busybox() {
 
   case "$_BASHUNIT_DISTRO" in
@@ -79,6 +101,7 @@ bashunit::check_os::init
 
 export _BASHUNIT_OS
 export _BASHUNIT_DISTRO
+export -f bashunit::check_os::nproc
 export -f bashunit::check_os::is_alpine
 export -f bashunit::check_os::is_busybox
 export -f bashunit::check_os::is_ubuntu
@@ -86,20 +109,75 @@ export -f bashunit::check_os::is_nixos
 
 # str.sh
 
-# Strip ANSI escape codes and control characters
-function bashunit::str::strip_ansi() {
+_BASHUNIT_STR_STRIPPED_OUT=""
+
+# Strip ANSI escape codes and control characters, writing the result into the
+# global slot _BASHUNIT_STR_STRIPPED_OUT (no fork on the plain-text fast path).
+# Callers on hot paths (assert_equals/assert_not_equals) use this to avoid the
+# per-call command-substitution fork. See bash-style.md (return-slot pattern).
+function bashunit::str::strip_ansi_to_slot() {
   local input="$1"
   # Fast path: plain text with no backslash (echo -e no-op) and no control
-  # bytes (nothing for sed to strip) passes through unchanged. Avoids forking
-  # echo+sed on the common case, which runs twice per assert_equals.
+  # bytes (nothing for sed to strip) passes through unchanged, zero forks.
   case "$input" in
   *\\* | *[[:cntrl:]]*) ;;
   *)
-    echo -e "$input"
+    _BASHUNIT_STR_STRIPPED_OUT=$input
     return
     ;;
   esac
-  echo -e "$input" | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/[[:cntrl:]]//g'
+  # Pure-bash path for short strings without backslashes: display lines (e.g.
+  # the per-test "✓ Passed … 3ms" alignment on systems whose clock is fork-free)
+  # land here, so a colored line does not cost a sed fork per test. Strip
+  # CSI sequences segment-wise, then sweep remaining control bytes; the size
+  # guard avoids bash's quadratic pattern-substitution on large captures and
+  # `*\\*` still defers to `echo -e` semantics below.
+  case "$input" in
+  *\\*) ;;
+  *)
+    if [ "${#input}" -le 1024 ]; then
+      local out="" rest="$input" params
+      while :; do
+        case "$rest" in
+        *$'\x1b'\[*)
+          out="$out${rest%%$'\x1b'\[*}"
+          rest="${rest#*$'\x1b'\[}"
+          params=""
+          while :; do
+            case "$rest" in
+            [0-9\;]*)
+              params="$params${rest%"${rest#?}"}"
+              rest="${rest#?}"
+              ;;
+            *) break ;;
+            esac
+          done
+          case "$rest" in
+          # Same finals sed strips; anything else keeps its printable residue
+          # (the ESC itself falls to the control-byte sweep, exactly like sed).
+          m* | K*) rest="${rest#?}" ;;
+          *) out="${out}[${params}" ;;
+          esac
+          ;;
+        *)
+          out="$out$rest"
+          break
+          ;;
+        esac
+      done
+      _BASHUNIT_STR_STRIPPED_OUT=${out//[[:cntrl:]]/}
+      return
+    fi
+    ;;
+  esac
+  _BASHUNIT_STR_STRIPPED_OUT=$(echo -e "$input" | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/[[:cntrl:]]//g')
+}
+
+# Strip ANSI escape codes and control characters, echoing the result.
+# Thin wrapper over the return-slot variant for callers that want stdout.
+function bashunit::str::strip_ansi() {
+  bashunit::str::strip_ansi_to_slot "$1"
+  echo "$_BASHUNIT_STR_STRIPPED_OUT"
 }
 
 function bashunit::str::rpad() {
@@ -113,8 +191,8 @@ function bashunit::str::rpad() {
   fi
 
   # Remove ANSI escape sequences (non-visible characters) for length calculation
-  # shellcheck disable=SC2155
-  local clean_left_text=$(bashunit::str::strip_ansi "$left_text")
+  bashunit::str::strip_ansi_to_slot "$left_text"
+  local clean_left_text=$_BASHUNIT_STR_STRIPPED_OUT
 
   local is_truncated=false
   # If the visible left text exceeds the padding, truncate it and add "..."
@@ -241,7 +319,21 @@ function bashunit::temp_dir() {
 function bashunit::cleanup_testcase_temp_files() {
   bashunit::internal_log "cleanup_testcase_temp_files"
   if [ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]; then
-    rm -rf "$BASHUNIT_TEMP_DIR/${BASHUNIT_CURRENT_TEST_ID}"_*
+    # Probe the glob in pure bash first: most tests create no temp file, so
+    # skipping the rm avoids a fork per test (#764). A non-matching glob either
+    # stays literal (nullglob off) or yields an empty array (nullglob on);
+    # ${matches[0]:-} handles both under set -u, and [ -e ] is false in each
+    # case. temp_file runs in a $(...) subshell, so a global flag could not
+    # reach this trap; checking the filesystem is the only reliable signal.
+    # Declare and assign separately: bash 3.0 does not expand a compound array
+    # assignment attached to `local`, it stores the literal "(glob)" instead.
+    local matches
+    matches=("$BASHUNIT_TEMP_DIR/${BASHUNIT_CURRENT_TEST_ID}"_*)
+    # if-form, not `[ ] && rm`: as the function's last statement the skip path
+    # would return 1, which is a death sentence for callers under set -e (#836)
+    if [ -e "${matches[0]:-}" ]; then
+      rm -rf "${matches[@]}"
+    fi
   fi
 }
 
@@ -415,8 +507,14 @@ function bashunit::math::calculate() {
     ;;
   esac
 
-  # Remove leading zeros from integers
-  expr=$(echo "$expr" | sed -E 's/\b0*([1-9][0-9]*)/\1/g')
+  # Remove leading zeros from integers so $((...)) does not read them as octal.
+  # Only fork sed when a leading zero is actually present — the common callers
+  # (clock durations) never produce one, so the no-bc path stays fork-free.
+  case "$expr" in
+  0[0-9]* | *[!0-9.]0[0-9]*)
+    expr=$(echo "$expr" | sed -E 's/\b0*([1-9][0-9]*)/\1/g')
+    ;;
+  esac
 
   local result=$((expr))
   echo "$result"
@@ -607,16 +705,39 @@ function bashunit::parallel::init() {
   mkdir -p "$TEMP_DIR_PARALLEL_TEST_SUITE"
 }
 
-function bashunit::parallel::is_enabled() {
-  bashunit::internal_log "bashunit::parallel::is_enabled" \
-    "requested:$BASHUNIT_PARALLEL_RUN" "os:${_BASHUNIT_OS:-Unknown}"
+# Cached result of resolve_enabled ("true"/"false"); empty until resolved.
+_BASHUNIT_PARALLEL_ENABLED=""
 
-  if bashunit::env::is_parallel_run_enabled &&
+# Pure predicate: parallel requested AND running on a supported OS. No caching
+# or logging, so it is safe to call fresh (e.g. from unit tests).
+function bashunit::parallel::_compute_enabled() {
+  bashunit::env::is_parallel_run_enabled &&
     (bashunit::check_os::is_macos || bashunit::check_os::is_ubuntu ||
-      bashunit::check_os::is_alpine || bashunit::check_os::is_windows); then
-    return 0
+      bashunit::check_os::is_alpine || bashunit::check_os::is_windows)
+}
+
+# Resolve parallel mode once (after arg parsing) into _BASHUNIT_PARALLEL_ENABLED
+# so is_enabled becomes a pure global read on the per-test hot path. The env +
+# OS checks are constant for the whole run.
+function bashunit::parallel::resolve_enabled() {
+  if bashunit::parallel::_compute_enabled; then
+    _BASHUNIT_PARALLEL_ENABLED=true
+  else
+    _BASHUNIT_PARALLEL_ENABLED=false
   fi
-  return 1
+  bashunit::internal_log "bashunit::parallel::resolve_enabled" \
+    "requested:$BASHUNIT_PARALLEL_RUN" "os:${_BASHUNIT_OS:-Unknown}" \
+    "enabled:$_BASHUNIT_PARALLEL_ENABLED"
+}
+
+function bashunit::parallel::is_enabled() {
+  case "$_BASHUNIT_PARALLEL_ENABLED" in
+  true) return 0 ;;
+  false) return 1 ;;
+  esac
+  # Not resolved yet (e.g. unit tests call is_enabled directly): compute fresh
+  # without caching so per-test env/OS changes are still honoured.
+  bashunit::parallel::_compute_enabled
 }
 
 # env.sh
@@ -666,6 +787,19 @@ function bashunit::env::load_config_file() {
   done <"$file"
 }
 
+##
+# Echoes $1 when it is a positive integer, otherwise echoes the default $2.
+# Arguments: $1 candidate value, $2 fallback default
+##
+function bashunit::env::positive_int_or_default() {
+  local value="$1"
+  local default="$2"
+  case "$value" in
+  '' | *[!0-9]* | 0) echo "$default" ;;
+  *) echo "$value" ;;
+  esac
+}
+
 # Load project config (lower precedence than env vars, .env and CLI flags).
 # Load .env file (skip if --skip-env-file is used to keep shell environment intact)
 if [ "${BASHUNIT_SKIP_ENV_FILE:-false}" != "true" ]; then
@@ -705,6 +839,12 @@ _BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH="80"
 : "${BASHUNIT_REPORT_TAP:=${REPORT_TAP:=$_BASHUNIT_DEFAULT_REPORT_TAP}}"
 : "${BASHUNIT_REPORT_JSON:=${REPORT_JSON:=$_BASHUNIT_DEFAULT_REPORT_JSON}}"
 
+# Watch mode polling interval (seconds) used by the pure-shell fallback
+_BASHUNIT_DEFAULT_WATCH_INTERVAL="2"
+: "${BASHUNIT_WATCH_INTERVAL:=${WATCH_INTERVAL:=$_BASHUNIT_DEFAULT_WATCH_INTERVAL}}"
+BASHUNIT_WATCH_INTERVAL=$(bashunit::env::positive_int_or_default \
+  "$BASHUNIT_WATCH_INTERVAL" "$_BASHUNIT_DEFAULT_WATCH_INTERVAL")
+
 # Coverage
 : "${BASHUNIT_COVERAGE:=${COVERAGE:=$_BASHUNIT_DEFAULT_COVERAGE}}"
 : "${BASHUNIT_COVERAGE_PATHS:=${COVERAGE_PATHS:=$_BASHUNIT_DEFAULT_COVERAGE_PATHS}}"
@@ -721,7 +861,8 @@ _BASHUNIT_DEFAULT_SHOW_HEADER="true"
 _BASHUNIT_DEFAULT_HEADER_ASCII_ART="false"
 _BASHUNIT_DEFAULT_SIMPLE_OUTPUT="false"
 _BASHUNIT_DEFAULT_STOP_ON_FAILURE="false"
-_BASHUNIT_DEFAULT_SHOW_EXECUTION_TIME="true"
+# "auto" shows per-test times only when the clock is fork-free (#765).
+_BASHUNIT_DEFAULT_SHOW_EXECUTION_TIME="auto"
 _BASHUNIT_DEFAULT_VERBOSE="false"
 _BASHUNIT_DEFAULT_BENCH_MODE="false"
 _BASHUNIT_DEFAULT_NO_OUTPUT="false"
@@ -734,6 +875,7 @@ _BASHUNIT_DEFAULT_SKIP_ENV_FILE="false"
 _BASHUNIT_DEFAULT_LOGIN_SHELL="false"
 _BASHUNIT_DEFAULT_FAILURES_ONLY="false"
 _BASHUNIT_DEFAULT_NO_COLOR="false"
+_BASHUNIT_DEFAULT_NO_DIFF="false"
 _BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE="true"
 _BASHUNIT_DEFAULT_NO_PROGRESS="false"
 _BASHUNIT_DEFAULT_OUTPUT_FORMAT=""
@@ -771,6 +913,7 @@ _BASHUNIT_DEFAULT_SHARD_TOTAL=""
 : "${BASHUNIT_LOGIN_SHELL:=${LOGIN_SHELL:=$_BASHUNIT_DEFAULT_LOGIN_SHELL}}"
 : "${BASHUNIT_FAILURES_ONLY:=${FAILURES_ONLY:=$_BASHUNIT_DEFAULT_FAILURES_ONLY}}"
 : "${BASHUNIT_SHOW_OUTPUT_ON_FAILURE:=${SHOW_OUTPUT_ON_FAILURE:=$_BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE}}"
+: "${BASHUNIT_NO_DIFF:=${NO_DIFF:=$_BASHUNIT_DEFAULT_NO_DIFF}}"
 : "${BASHUNIT_NO_PROGRESS:=${NO_PROGRESS:=$_BASHUNIT_DEFAULT_NO_PROGRESS}}"
 : "${BASHUNIT_OUTPUT_FORMAT:=${OUTPUT_FORMAT:=$_BASHUNIT_DEFAULT_OUTPUT_FORMAT}}"
 : "${BASHUNIT_FAIL_ON_RISKY:=${FAIL_ON_RISKY:=$_BASHUNIT_DEFAULT_FAIL_ON_RISKY}}"
@@ -819,14 +962,20 @@ function bashunit::env::test_timeout_secs() {
 # Prints the number of extra attempts for a failed test (0 = no retry).
 # A non-numeric value is treated as 0.
 ##
-function bashunit::env::retry_count() {
+# Validates BASHUNIT_RETRY into the integer global _BASHUNIT_RETRY_VALIDATED.
+# In-shell (no fork) so the per-test hot path can read the global instead of
+# capturing retry_count in a $(...) subshell every test (#764).
+_BASHUNIT_RETRY_VALIDATED=0
+function bashunit::env::resolve_retry_count() {
   case "${BASHUNIT_RETRY:-0}" in
-  '' | *[!0-9]*)
-    printf '%s' "0"
-    return
-    ;;
+  '' | *[!0-9]*) _BASHUNIT_RETRY_VALIDATED=0 ;;
+  *) _BASHUNIT_RETRY_VALIDATED="${BASHUNIT_RETRY:-0}" ;;
   esac
-  printf '%s' "${BASHUNIT_RETRY:-0}"
+}
+
+function bashunit::env::retry_count() {
+  bashunit::env::resolve_retry_count
+  printf '%s' "$_BASHUNIT_RETRY_VALIDATED"
 }
 
 function bashunit::env::is_random_order_enabled() {
@@ -869,7 +1018,18 @@ function bashunit::env::is_stop_on_failure_enabled() {
 }
 
 function bashunit::env::is_show_execution_time_enabled() {
-  [ "$BASHUNIT_SHOW_EXECUTION_TIME" = "true" ]
+  case "$BASHUNIT_SHOW_EXECUTION_TIME" in
+  true) return 0 ;;
+  auto) ! bashunit::clock::is_expensive ;;
+  *) return 1 ;;
+  esac
+}
+
+# The total "Time taken" footer costs two clock reads per run (negligible), so it
+# stays visible in "auto" mode even when per-test timing is skipped; only an
+# explicit "false" hides it (#765).
+function bashunit::env::is_total_execution_time_enabled() {
+  [ "$BASHUNIT_SHOW_EXECUTION_TIME" != "false" ]
 }
 
 function bashunit::env::is_dev_mode_enabled() {
@@ -930,6 +1090,12 @@ function bashunit::env::is_no_progress_enabled() {
 
 function bashunit::env::is_no_color_enabled() {
   [ "$BASHUNIT_NO_COLOR" = "true" ]
+}
+
+function bashunit::env::is_diff_enabled() {
+  # :- guard: a user (or test) may have unset BASHUNIT_NO_DIFF; a bare read
+  # dies under set -u (--strict) (#836)
+  [ "${BASHUNIT_NO_DIFF:-}" != "true" ]
 }
 
 ##
@@ -1064,15 +1230,50 @@ TERMINAL_WIDTH="$(bashunit::env::find_terminal_width)"
 CAT="$(command -v cat)"
 GREP="$(command -v grep)"
 MKTEMP="$(command -v mktemp)"
-FAILURES_OUTPUT_PATH=$("$MKTEMP")
-SKIPPED_OUTPUT_PATH=$("$MKTEMP")
-INCOMPLETE_OUTPUT_PATH=$("$MKTEMP")
-RISKY_OUTPUT_PATH=$("$MKTEMP")
-PROFILE_OUTPUT_PATH=$("$MKTEMP")
+# Deferred-output scratch files. Each used to be its own `mktemp` fork; at ~258
+# nested cold starts in the acceptance suite that is ~1.5k forks and dominates
+# cold-start cost (#798). Derive them from one run-unique directory instead:
+# `bashunit::random_str` is fork-free and every consumer appends with `>>` (which
+# creates the file lazily) or guards reads with `[ -s ... ]`, so the files need
+# not be pre-created. The random suffix keeps the directory unique across
+# recursive and parallel invocations, matching TEMP_DIR_PARALLEL_TEST_SUITE.
+_BASHUNIT_RUN_OUTPUT_DIR="${TMPDIR:-/tmp}/bashunit/run/${_BASHUNIT_OS:-Unknown}/$(bashunit::random_str 8)"
+FAILURES_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/failures"
+SKIPPED_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/skipped"
+INCOMPLETE_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/incomplete"
+RISKY_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/risky"
+PROFILE_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/profile"
+# Collects "<test_file>:<function_name>" for every failing test in a run so the
+# next --rerun-failed can replay just those. Shared across parallel subshells.
+RERUN_FAILED_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/rerun-failed"
 
-# Initialize temp directory once at startup for performance
+# Shared temp directory, initialized once at startup for performance.
 BASHUNIT_TEMP_DIR="${TMPDIR:-/tmp}/bashunit/tmp"
-mkdir -p "$BASHUNIT_TEMP_DIR" 2>/dev/null || true
+
+# Create both scratch directories in a single `mkdir -p` fork.
+mkdir -p "$_BASHUNIT_RUN_OUTPUT_DIR" "$BASHUNIT_TEMP_DIR" 2>/dev/null || true
+
+# Removes this run's scratch directory (guarded like parallel::cleanup so a
+# broken variable can never turn the rm loose elsewhere). Called at the end of
+# a run and on SIGINT; without it every invocation leaks one directory.
+function bashunit::env::cleanup_run_output_dir() {
+  local target="$_BASHUNIT_RUN_OUTPUT_DIR"
+  case "$target" in
+  */bashunit/run/*)
+    rm -rf "$target"
+    ;;
+  *)
+    bashunit::internal_log "env::cleanup_run_output_dir" "refused unsafe path:$target"
+    return 1
+    ;;
+  esac
+}
+
+# Cover early-exit paths (--version, --help, doc, init, ...). The test-run path
+# replaces this trap in main.sh and calls the cleanup explicitly instead; child
+# subshells never inherit EXIT traps, so a parallel worker cannot remove the
+# directory mid-run.
+trap 'bashunit::env::cleanup_run_output_dir' EXIT
 
 if bashunit::env::is_dev_mode_enabled; then
   bashunit::internal_log "info" "Dev log enabled" "file:$BASHUNIT_DEV_LOG"
@@ -3383,12 +3584,23 @@ function bashunit::clock::_choose_impl() {
     esac
   fi
 
-  # 3. Try Perl with Time::HiRes
+  # 3. Try Perl with Time::HiRes. Probe by reading the actual time (not an empty
+  # `-e ""`) so the pending first read reuses this fork instead of paying a
+  # second one; a non-digit/empty result means perl or Time::HiRes is missing, so
+  # fall through. The value is seeded into the return slot for now_to_slot.
   attempts[attempts_count]="Perl"
   attempts_count=$((attempts_count + 1))
-  if bashunit::dependencies::has_perl && perl -MTime::HiRes -e "" &>/dev/null; then
-    _BASHUNIT_CLOCK_NOW_IMPL="perl"
-    return 0
+  if bashunit::dependencies::has_perl; then
+    local perl_now
+    perl_now="$(perl -MTime::HiRes -e 'printf("%.0f\n", Time::HiRes::time() * 1000000000)' 2>/dev/null)"
+    case "$perl_now" in
+    '' | *[!0-9]*) ;;
+    *)
+      _BASHUNIT_CLOCK_NOW_IMPL="perl"
+      _BASHUNIT_CLOCK_NOW_OUT="$perl_now"
+      return 0
+      ;;
+    esac
   fi
 
   # 4. Try Python 3 with time module
@@ -3429,44 +3641,72 @@ function bashunit::clock::_choose_impl() {
   return 1
 }
 
-function bashunit::clock::now() {
+# Returns 0 when the chosen clock impl forks an interpreter (perl/python/node/
+# powershell), so callers can skip optional timing to avoid a per-read fork (#765).
+function bashunit::clock::is_expensive() {
+  [ -n "$_BASHUNIT_CLOCK_NOW_IMPL" ] || bashunit::clock::_choose_impl >/dev/null 2>&1 || true
+  case "$_BASHUNIT_CLOCK_NOW_IMPL" in
+  perl | python | node | powershell) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+_BASHUNIT_CLOCK_NOW_OUT=""
+
+# Return-slot variant of bashunit::clock::now: writes the current time in
+# nanoseconds into _BASHUNIT_CLOCK_NOW_OUT. The `shell` branch reads
+# EPOCHREALTIME directly (folding in shell_time) so the per-test hot path pays
+# no command-substitution fork on Bash 5.0+; `date-seconds` forks once instead
+# of twice. Interpreter/`date` branches keep a single internal fork.
+# Returns: 0 on success, 1 when no clock implementation is available.
+function bashunit::clock::now_to_slot() {
   if [ -z "$_BASHUNIT_CLOCK_NOW_IMPL" ]; then
+    _BASHUNIT_CLOCK_NOW_OUT=""
     bashunit::clock::_choose_impl || return 1
+    # _choose_impl may have already read the current time while selecting an
+    # interpreter impl (e.g. perl); reuse that value for this first read instead
+    # of forking a second interpreter.
+    if [ -n "$_BASHUNIT_CLOCK_NOW_OUT" ]; then
+      return 0
+    fi
   fi
 
   case "$_BASHUNIT_CLOCK_NOW_IMPL" in
   perl)
-    perl -MTime::HiRes -e 'printf("%.0f\n", Time::HiRes::time() * 1000000000)'
+    _BASHUNIT_CLOCK_NOW_OUT="$(perl -MTime::HiRes -e 'printf("%.0f\n", Time::HiRes::time() * 1000000000)')"
     ;;
   python)
-    python - <<'EOF'
+    _BASHUNIT_CLOCK_NOW_OUT="$(
+      python - <<'EOF'
 import time, sys
 sys.stdout.write(str(int(time.time() * 1000000000)))
 EOF
+    )"
     ;;
   node)
-    node -e 'process.stdout.write((BigInt(Date.now()) * 1000000n).toString())'
+    _BASHUNIT_CLOCK_NOW_OUT="$(node -e 'process.stdout.write((BigInt(Date.now()) * 1000000n).toString())')"
     ;;
   powershell)
-    powershell -Command "\
+    _BASHUNIT_CLOCK_NOW_OUT="$(powershell -Command "\
         \$unixEpoch = [DateTime]'1970-01-01 00:00:00';\
         \$now = [DateTime]::UtcNow;\
         \$ticksSinceEpoch = (\$now - \$unixEpoch).Ticks;\
         \$nanosecondsSinceEpoch = \$ticksSinceEpoch * 100;\
         Write-Output \$nanosecondsSinceEpoch\
-      "
+      ")"
     ;;
   date)
-    date +%s%N
+    _BASHUNIT_CLOCK_NOW_OUT="$(date +%s%N)"
     ;;
   date-seconds)
     local seconds
     seconds=$(date +%s)
-    echo "$((seconds * 1000000000))"
+    _BASHUNIT_CLOCK_NOW_OUT="$((seconds * 1000000000))"
     ;;
   shell)
-    # shellcheck disable=SC2155
-    local shell_time="$(bashunit::clock::shell_time)"
+    # Read EPOCHREALTIME directly (no shell_time subshell) on the hot path;
+    # both '.' and ',' decimal separators are handled for locale portability.
+    local shell_time="${EPOCHREALTIME:-}"
     local seconds="${shell_time%%[.,]*}"
     local microseconds="${shell_time#*[.,]}"
     if [ "$seconds" = "$shell_time" ]; then
@@ -3477,13 +3717,18 @@ EOF
     microseconds="${microseconds:0:6}"
     microseconds="${microseconds#"${microseconds%%[!0]*}"}"
     microseconds="${microseconds:-0}"
-    echo "$(( (seconds * 1000000000) + (microseconds * 1000) ))"
+    _BASHUNIT_CLOCK_NOW_OUT="$(((seconds * 1000000000) + (microseconds * 1000)))"
     ;;
   *)
     bashunit::clock::_choose_impl || return 1
-    bashunit::clock::now
+    bashunit::clock::now_to_slot
     ;;
   esac
+}
+
+function bashunit::clock::now() {
+  bashunit::clock::now_to_slot || return 1
+  echo "$_BASHUNIT_CLOCK_NOW_OUT"
 }
 
 function bashunit::clock::shell_time() {
@@ -3517,12 +3762,15 @@ function bashunit::clock::init() {
 
 # state.sh
 
-# Cache base64 -w flag support (Alpine needs -w 0, macOS does not support -w)
-if [ "$(base64 --help 2>&1 | "$GREP" -c -- "-w" || true)" -gt 0 ]; then
-  _BASHUNIT_BASE64_WRAP_FLAG=true
-else
-  _BASHUNIT_BASE64_WRAP_FLAG=false
-fi
+# Cache base64 -w flag support (Alpine needs -w 0, macOS does not support -w).
+# Scrape `base64 --help` once and match with a shell `case` instead of piping
+# into a `grep` fork — same detection, one fewer fork per cold start.
+_bashunit_base64_help="$(base64 --help 2>&1 || true)"
+case "$_bashunit_base64_help" in
+*-w*) _BASHUNIT_BASE64_WRAP_FLAG=true ;;
+*) _BASHUNIT_BASE64_WRAP_FLAG=false ;;
+esac
+unset _bashunit_base64_help
 
 _BASHUNIT_TESTS_PASSED=0
 _BASHUNIT_TESTS_FAILED=0
@@ -3745,25 +3993,42 @@ function bashunit::state::initialize_assertions_count() {
   _BASHUNIT_ASSERTION_FAILED_IN_TEST=0
 }
 
+# base64-encodes a field, writing the result into _BASHUNIT_STATE_ENCODED_OUT.
+# Empty values (the common case for title/hook message, and output on a passing
+# test) encode to an empty field with no base64 fork (#762). base64 of "" is ""
+# anyway, so this stays wire-compatible.
+_BASHUNIT_STATE_ENCODED_OUT=""
+function bashunit::state::encode_field() {
+  local value=$1
+  if [ -z "$value" ]; then
+    _BASHUNIT_STATE_ENCODED_OUT=""
+    return
+  fi
+  if [ "$_BASHUNIT_BASE64_WRAP_FLAG" = true ]; then
+    # Alpine requires the -w 0 option to avoid wrapping
+    _BASHUNIT_STATE_ENCODED_OUT=$(echo -n "$value" | base64 -w 0)
+  else
+    _BASHUNIT_STATE_ENCODED_OUT=$(echo -n "$value" | base64)
+  fi
+}
+
 function bashunit::state::export_subshell_context() {
   local encoded_test_output
   local encoded_test_title
-
   local encoded_test_hook_message
 
-  if [ "$_BASHUNIT_BASE64_WRAP_FLAG" = true ]; then
-    # Alpine requires the -w 0 option to avoid wrapping
-    encoded_test_output=$(echo -n "$_BASHUNIT_TEST_OUTPUT" | base64 -w 0)
-    encoded_test_title=$(echo -n "$_BASHUNIT_TEST_TITLE" | base64 -w 0)
-    encoded_test_hook_message=$(echo -n "$_BASHUNIT_TEST_HOOK_MESSAGE" | base64 -w 0)
-  else
-    # macOS and others: default base64 without wrapping
-    encoded_test_output=$(echo -n "$_BASHUNIT_TEST_OUTPUT" | base64)
-    encoded_test_title=$(echo -n "$_BASHUNIT_TEST_TITLE" | base64)
-    encoded_test_hook_message=$(echo -n "$_BASHUNIT_TEST_HOOK_MESSAGE" | base64)
-  fi
+  bashunit::state::encode_field "$_BASHUNIT_TEST_OUTPUT"
+  encoded_test_output=$_BASHUNIT_STATE_ENCODED_OUT
+  bashunit::state::encode_field "$_BASHUNIT_TEST_TITLE"
+  encoded_test_title=$_BASHUNIT_STATE_ENCODED_OUT
+  bashunit::state::encode_field "$_BASHUNIT_TEST_HOOK_MESSAGE"
+  encoded_test_hook_message=$_BASHUNIT_STATE_ENCODED_OUT
 
-  cat <<EOF
+  # Emit the encoded result payload with `printf` (a builtin) instead of a
+  # `cat <<EOF` heredoc: this runs once per test, so avoiding the fork removes
+  # one process per test. The `\`-continued string keeps the per-field layout
+  # and produces the exact same single line the heredoc did.
+  local payload="\
 ##ASSERTIONS_FAILED=$_BASHUNIT_ASSERTIONS_FAILED\
 ##ASSERTIONS_PASSED=$_BASHUNIT_ASSERTIONS_PASSED\
 ##ASSERTIONS_SKIPPED=$_BASHUNIT_ASSERTIONS_SKIPPED\
@@ -3773,8 +4038,8 @@ function bashunit::state::export_subshell_context() {
 ##TEST_HOOK_FAILURE=$_BASHUNIT_TEST_HOOK_FAILURE\
 ##TEST_HOOK_MESSAGE=$encoded_test_hook_message\
 ##TEST_TITLE=$encoded_test_title\
-##TEST_OUTPUT=$encoded_test_output##
-EOF
+##TEST_OUTPUT=$encoded_test_output##"
+  printf '%s\n' "$payload"
 }
 
 function bashunit::state::calculate_total_assertions() {
@@ -4001,7 +4266,11 @@ function bashunit::console_header::print_version() {
     # Skip counting in parallel+simple mode for faster startup
     total_tests=0
   else
-    total_tests=$(bashunit::helper::find_total_tests "$filter" "$@")
+    # Read via the return slot, not $(...): the capture subshell would discard
+    # the provider-map cache find_total_tests builds per file, forcing the
+    # runner to re-scan each file with a second awk fork.
+    bashunit::helper::find_total_tests "$filter" "$@" >/dev/null
+    total_tests=$_BASHUNIT_HELPER_TOTAL_TESTS_OUT
   fi
 
   if bashunit::env::is_header_ascii_art_enabled; then
@@ -4081,7 +4350,7 @@ Options:
   --tag <name>                Only run tests with matching @tag (repeatable, OR logic)
   --exclude-tag <name>        Skip tests with matching @tag (repeatable, exclude wins)
   --log-junit, --report-junit <file>  Write JUnit XML report
-  -j, --jobs <N>              Run tests in parallel with max N concurrent jobs
+  -j, --jobs <N|auto>         Run tests in parallel with max N concurrent jobs ("auto" = CPU cores)
   -p, --parallel              Run tests in parallel (unlimited concurrency)
   --no-parallel               Run tests sequentially
   -r, --report-html <file>    Write HTML report
@@ -4097,6 +4366,7 @@ Options:
   --random-order              Randomize test execution order
   --seed <n>                  Seed for --random-order (reproducible shuffle)
   --shard <i>/<n>             Run shard i of n (split the suite across runners)
+  --rerun-failed              Replay only the tests that failed on the last run (.bashunit/last-failed)
   -vvv, --verbose             Show execution details
   --debug [file]              Enable shell debug mode
   --no-output                 Suppress all output
@@ -4418,7 +4688,7 @@ function bashunit::console_results::render_result() {
 }
 
 function bashunit::console_results::print_execution_time() {
-  if ! bashunit::env::is_show_execution_time_enabled; then
+  if ! bashunit::env::is_total_execution_time_enabled; then
     return
   fi
 
@@ -4512,9 +4782,11 @@ function bashunit::console_results::print_successful_test() {
   local duration=${1:-"0"}
   shift
 
+  # Pure-bash concatenation (the printf only did %s substitution) to avoid a
+  # $(...) fork per passing test (#764).
   local line
   if [ -z "$*" ]; then
-    line=$(printf "%s✓ Passed%s: %s" "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_DEFAULT" "$test_name")
+    line="${_BASHUNIT_COLOR_PASSED}✓ Passed${_BASHUNIT_COLOR_DEFAULT}: ${test_name}"
   else
     local quoted_args=""
     local arg
@@ -4525,8 +4797,7 @@ function bashunit::console_results::print_successful_test() {
         quoted_args="$quoted_args, '$arg'"
       fi
     done
-    line=$(printf "%s✓ Passed%s: %s (%s)" \
-      "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_DEFAULT" "$test_name" "$quoted_args")
+    line="${_BASHUNIT_COLOR_PASSED}✓ Passed${_BASHUNIT_COLOR_DEFAULT}: ${test_name} (${quoted_args})"
   fi
 
   # Retry annotation (e.g. " (retry 1/2)") set by the runner when a test only
@@ -4586,6 +4857,47 @@ ${_BASHUNIT_COLOR_BOLD}'%s'${_BASHUNIT_COLOR_DEFAULT}\n" \
   bashunit::state::print_line "failure" "$line"
 }
 
+##
+# Renders a git word-diff of two files, indented, and echoes it. Colorized
+# unless --no-color is active. Empty when git is unavailable or files match.
+# Shared by the snapshot-failure and multiline assert-failure renderers.
+# Arguments: $1 expected file path, $2 actual file path
+##
+function bashunit::console_results::render_diff() {
+  local expected_file=$1
+  local actual_file=$2
+
+  if ! bashunit::dependencies::has_git; then
+    return 0
+  fi
+
+  local color_flag="--color=always"
+  if bashunit::env::is_no_color_enabled; then
+    color_flag="--color=never"
+  fi
+
+  # `git diff` exits non-zero when the files differ; the `|| true` keeps that
+  # from tripping `set -e`/`pipefail` under --strict. `tail -n +6` drops git's
+  # header lines; `sed` indents the body.
+  git diff --no-index --word-diff "$color_flag" \
+    "$expected_file" "$actual_file" 2>/dev/null |
+    tail -n +6 | sed "s/^/    /" || true
+}
+
+##
+# Echoes a value's first line, appending an ellipsis when it spans several
+# lines. Used to keep the inline quoted value on one line when a diff follows.
+##
+function bashunit::console_results::first_line_ellipsis() {
+  local text=$1
+  local first="${text%%$'\n'*}"
+  if [ "$first" != "$text" ]; then
+    printf '%s…' "$first"
+  else
+    printf '%s' "$text"
+  fi
+}
+
 function bashunit::console_results::print_failed_test() {
   local function_name=$1
   local expected=$2
@@ -4594,12 +4906,41 @@ function bashunit::console_results::print_failed_test() {
   local extra_key=${5-}
   local extra_value=${6-}
 
+  # For multiline values, render a unified diff below the header (git required,
+  # opt out with BASHUNIT_NO_DIFF). Single-line output stays byte-identical.
+  local show_diff=false
+  case "$expected$actual" in
+  *$'\n'*)
+    if bashunit::env::is_diff_enabled && bashunit::dependencies::has_git; then
+      show_diff=true
+    fi
+    ;;
+  esac
+
+  local display_expected=$expected
+  local display_actual=$actual
+  if [ "$show_diff" = true ]; then
+    display_expected="$(bashunit::console_results::first_line_ellipsis "$expected")"
+    display_actual="$(bashunit::console_results::first_line_ellipsis "$actual")"
+  fi
+
   local line
   line="$(printf "\
 ${_BASHUNIT_COLOR_FAILED}✗ Failed${_BASHUNIT_COLOR_DEFAULT}: %s
     ${_BASHUNIT_COLOR_FAINT}Expected${_BASHUNIT_COLOR_DEFAULT} ${_BASHUNIT_COLOR_BOLD}'%s'${_BASHUNIT_COLOR_DEFAULT}
     ${_BASHUNIT_COLOR_FAINT}%s${_BASHUNIT_COLOR_DEFAULT} ${_BASHUNIT_COLOR_BOLD}'%s'${_BASHUNIT_COLOR_DEFAULT}\n" \
-    "${function_name}" "${expected}" "${failure_condition_message}" "${actual}")"
+    "${function_name}" "${display_expected}" "${failure_condition_message}" "${display_actual}")"
+
+  if [ "$show_diff" = true ]; then
+    local _expected_file _actual_file
+    _expected_file="$(bashunit::temp_file diff_expected)"
+    _actual_file="$(bashunit::temp_file diff_actual)"
+    printf '%s\n' "$expected" >"$_expected_file"
+    printf '%s\n' "$actual" >"$_actual_file"
+    line="$line
+$(bashunit::console_results::render_diff "$_expected_file" "$_actual_file")"
+    rm -f "$_expected_file" "$_actual_file"
+  fi
 
   if [ -n "$extra_key" ]; then
     line="$line$(printf "\
@@ -4626,14 +4967,7 @@ function bashunit::console_results::print_failed_snapshot_test() {
     local actual_file="${snapshot_file}.tmp"
     echo "$actual_content" >"$actual_file"
 
-    # `git diff` exits non-zero when the files differ; guard with `|| true` so
-    # the assignment does not trip `set -e`/`pipefail` under --strict.
-    local git_diff_output
-    git_diff_output="$(git diff --no-index --word-diff --color=always \
-      "$snapshot_file" "$actual_file" 2>/dev/null |
-      tail -n +6 | sed "s/^/    /")" || true
-
-    line="$line$git_diff_output"
+    line="$line$(bashunit::console_results::render_diff "$snapshot_file" "$actual_file")"
     rm "$actual_file"
   else
     line="$line$(bashunit::console_results::snapshot_line_diff \
@@ -4656,7 +4990,11 @@ function bashunit::console_results::snapshot_line_diff() {
 
   # Explicit empty-array init so referencing the arrays is safe under `set -u`
   # on Bash 4.4+ (Bash 3.x is lenient; newer Bash treats an unset array as unbound).
-  local expected_lines=() actual_lines=()
+  # Declare and assign separately: bash 3.0 does not expand a compound array
+  # assignment attached to `local`, it stores the literal "()" as element 0.
+  local expected_lines actual_lines
+  expected_lines=()
+  actual_lines=()
   local _line=""
   local i=0
   while IFS= read -r _line || [ -n "$_line" ]; do
@@ -4919,6 +5257,29 @@ declare -r BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
 #
 # @return string The test function name, or fallback function name
 #
+_BASHUNIT_HELPER_TESTFN_OUT=""
+
+#
+# Return-slot variant of find_test_function_name: writes the result into
+# _BASHUNIT_HELPER_TESTFN_OUT with no fork. Must be called at the SAME stack
+# depth the echoing version would be captured at, so the fallback_depth default
+# keeps pointing at the caller of the assertion (see the echoing wrapper below).
+#
+function bashunit::helper::find_test_function_name_to_slot() {
+  local fallback_depth="${1:-2}"
+  local i
+  for ((i = 0; i < ${#FUNCNAME[@]}; i++)); do
+    local fn="${FUNCNAME[$i]}"
+    case "$fn" in
+    test_* | test[A-Z]*)
+      _BASHUNIT_HELPER_TESTFN_OUT=$fn
+      return
+      ;;
+    esac
+  done
+  _BASHUNIT_HELPER_TESTFN_OUT=${FUNCNAME[$fallback_depth]:-}
+}
+
 function bashunit::helper::find_test_function_name() {
   local fallback_depth="${1:-2}"
   local i
@@ -4945,22 +5306,32 @@ function bashunit::helper::find_test_function_name() {
 #
 # @return string Eg: "Some logic camelCase"
 #
-function bashunit::helper::normalize_test_function_name() {
+_BASHUNIT_HELPER_NORMALIZED_OUT=""
+
+#
+# Return-slot variant of normalize_test_function_name: writes the result into
+# _BASHUNIT_HELPER_NORMALIZED_OUT with no fork, removing the command-substitution
+# fork at the (failure-path) call sites in the assertion layer.
+#
+# @param $1 string Eg: "test_some_logic_camelCase"
+# @param $2 string Optional interpolated name
+#
+function bashunit::helper::normalize_test_function_name_to_slot() {
   local original_fn_name="${1-}"
   local interpolated_fn_name="${2-}"
 
-  local custom_title
-  custom_title="$(bashunit::state::get_test_title)"
+  # Read the reserved-namespace state globals directly (the accessors just echo
+  # them) to avoid a nested subshell fork on this per-test hot path (#764).
+  local custom_title="${_BASHUNIT_TEST_TITLE:-}"
   if [ -n "$custom_title" ]; then
-    echo "$custom_title"
+    _BASHUNIT_HELPER_NORMALIZED_OUT=$custom_title
     return
   fi
 
   if [ -z "${interpolated_fn_name-}" ]; then
     case "${original_fn_name}" in
     *"::"*)
-      local state_interpolated_fn_name
-      state_interpolated_fn_name="$(bashunit::state::get_current_test_interpolated_function_name)"
+      local state_interpolated_fn_name="${_BASHUNIT_CURRENT_TEST_INTERPOLATED_NAME:-}"
 
       if [ -n "$state_interpolated_fn_name" ]; then
         interpolated_fn_name="$state_interpolated_fn_name"
@@ -4996,7 +5367,17 @@ function bashunit::helper::normalize_test_function_name() {
   esac
   result="${first_char}${result:1}"
 
-  echo "$result"
+  _BASHUNIT_HELPER_NORMALIZED_OUT=$result
+}
+
+#
+# @param $1 string Eg: "test_some_logic_camelCase"
+#
+# @return string Eg: "Some logic camelCase"
+#
+function bashunit::helper::normalize_test_function_name() {
+  bashunit::helper::normalize_test_function_name_to_slot "${1-}" "${2-}"
+  echo "$_BASHUNIT_HELPER_NORMALIZED_OUT"
 }
 
 function bashunit::helper::escape_single_quotes() {
@@ -5057,8 +5438,8 @@ function bashunit::helper::encode_base64() {
 function bashunit::helper::decode_base64() {
   local value="$1"
 
-  # Handle empty string marker
-  if [ "$value" = "_BASHUNIT_EMPTY_" ]; then
+  # Empty input decodes to empty; short-circuit to skip the base64 fork (#762).
+  if [ -z "$value" ] || [ "$value" = "_BASHUNIT_EMPTY_" ]; then
     printf ''
     return
   fi
@@ -5078,22 +5459,44 @@ function bashunit::helper::check_duplicate_functions() {
     script="$BASHUNIT_WORKING_DIR/$script"
   fi
 
-  local filtered_lines
-  filtered_lines=$(grep -E '^[[:space:]]*(function[[:space:]]+)?test[a-zA-Z_][a-zA-Z0-9_]*\s*\(\)\s*\{' "$script")
-
-  local function_names
-  function_names=$(echo "$filtered_lines" | awk '{
-    for (i=1; i<=NF; i++) {
-      if ($i ~ /^test[a-zA-Z_][a-zA-Z0-9_]*\(\)$/) {
-        gsub(/\(\)/, "", $i)
-        print $i
-        break
+  # One awk pass over the file finds each test-function definition and emits only
+  # the names seen more than once, folding the former grep + awk + sort + uniq
+  # chain into a single awk (#761). The END block insertion-sorts the (tiny,
+  # usually empty) duplicate list itself, so no `sort` fork is needed to keep
+  # the output deterministic.
+  local duplicates
+  duplicates=$(awk '
+    /^[[:space:]]*(function[[:space:]]+)?test[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\(\)[[:space:]]*\{/ {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^test[a-zA-Z_][a-zA-Z0-9_]*\(\)$/) {
+          name = $i
+          gsub(/\(\)/, "", name)
+          if (++seen[name] == 2) {
+            dup[name] = 1
+          }
+          break
+        }
       }
     }
-  }')
-
-  local duplicates
-  duplicates=$(echo "$function_names" | sort | uniq -d)
+    END {
+      n = 0
+      for (name in dup) {
+        names[++n] = name
+      }
+      for (i = 2; i <= n; i++) {
+        v = names[i]
+        j = i - 1
+        while (j >= 1 && names[j] > v) {
+          names[j + 1] = names[j]
+          j--
+        }
+        names[j + 1] = v
+      }
+      for (i = 1; i <= n; i++) {
+        print names[i]
+      }
+    }
+  ' "$script")
   if [ -n "$duplicates" ]; then
     bashunit::state::set_duplicated_functions_merged "$script" "$duplicates"
     return 1
@@ -5158,13 +5561,13 @@ function bashunit::helper::find_files_recursive() {
   local path="${1%%/}"
   local pattern="${2:-*[tT]est.sh}"
 
+  # When the pattern targets *.sh test files, also match the .bash variant. Both
+  # the plain `*test.sh` and the default glob `*[tT]est.sh` end in `.sh`; a case
+  # match on either (no grep fork) is enough to decide.
   local alt_pattern=""
-  local _re='\[tT\]est\.sh$'
-  local _pattern_match=false
-  case "$pattern" in *test.sh) _pattern_match=true ;; esac
-  if [ "$_pattern_match" = true ] || [ "$(echo "$pattern" | "$GREP" -cE "$_re" || true)" -gt 0 ]; then
-    alt_pattern="${pattern%.sh}.bash"
-  fi
+  case "$pattern" in
+  *test.sh | *'[tT]est.sh') alt_pattern="${pattern%.sh}.bash" ;;
+  esac
 
   local _has_glob=false
   case "$path" in *"*"*) _has_glob=true ;; esac
@@ -5185,7 +5588,13 @@ function bashunit::helper::find_files_recursive() {
   fi
 }
 
-function bashunit::helper::normalize_variable_name() {
+_BASHUNIT_HELPER_VARNAME_OUT=""
+
+# Return-slot variant of normalize_variable_name: writes the result into
+# _BASHUNIT_HELPER_VARNAME_OUT with no fork, for hot-path callers that would
+# otherwise capture it with a command substitution (e.g. snapshot path
+# resolution, which calls it twice per assertion).
+function bashunit::helper::normalize_variable_name_to_slot() {
   local input_string="$1"
   local normalized_string="${input_string//[^a-zA-Z0-9_]/_}"
 
@@ -5197,32 +5606,144 @@ function bashunit::helper::normalize_variable_name() {
   *) normalized_string="_$normalized_string" ;;
   esac
 
-  builtin echo "$normalized_string"
+  _BASHUNIT_HELPER_VARNAME_OUT=$normalized_string
+}
+
+function bashunit::helper::normalize_variable_name() {
+  bashunit::helper::normalize_variable_name_to_slot "$1"
+  builtin echo "$_BASHUNIT_HELPER_VARNAME_OUT"
+}
+
+# Provider map for the most recently scanned script. Scanning a file once and
+# caching the test-function -> provider-function pairs replaces a per-test
+# grep+sed fork with a pure-bash lookup on the hot path (issue #763).
+_BASHUNIT_PROVIDER_MAP_SCRIPT=""
+_BASHUNIT_PROVIDER_MAP_FNS=()
+_BASHUNIT_PROVIDER_MAP_PROVIDERS=()
+_BASHUNIT_PROVIDER_FN_OUT=""
+# Set true when the scanned file carries the "# bashunit: no-parallel-tests"
+# opt-out; detected in the same awk pass to avoid a per-file grep fork (#774).
+_BASHUNIT_PROVIDER_MAP_NO_PARALLEL=false
+
+#
+# Resolves a script path, applying the issue #529 working-dir fallback.
+# Writes the resolved path into _BASHUNIT_PROVIDER_RESOLVED_OUT (empty if unreadable).
+#
+_BASHUNIT_PROVIDER_RESOLVED_OUT=""
+function bashunit::helper::_resolve_provider_script() {
+  local script=$1
+  # Handle directory changes in set_up_before_script (issue #529)
+  if [ ! -f "$script" ] && [ -n "${BASHUNIT_WORKING_DIR:-}" ]; then
+    script="$BASHUNIT_WORKING_DIR/$script"
+  fi
+  if [ ! -f "$script" ]; then
+    _BASHUNIT_PROVIDER_RESOLVED_OUT=""
+    return
+  fi
+  _BASHUNIT_PROVIDER_RESOLVED_OUT=$script
+}
+
+#
+# Scans a script once and caches its test-function -> provider-function pairs.
+# Memoized by resolved path, so repeated calls for the same file do not rescan.
+#
+# @param $1 string Path to the test script
+#
+function bashunit::helper::build_provider_map() {
+  bashunit::helper::_resolve_provider_script "$1"
+  local script=$_BASHUNIT_PROVIDER_RESOLVED_OUT
+
+  if [ -z "$script" ]; then
+    # Unreadable path: reset to an empty map keyed to this argument so a
+    # follow-up lookup returns empty without rescanning.
+    _BASHUNIT_PROVIDER_MAP_SCRIPT="$1"
+    _BASHUNIT_PROVIDER_MAP_FNS=()
+    _BASHUNIT_PROVIDER_MAP_PROVIDERS=()
+    _BASHUNIT_PROVIDER_MAP_NO_PARALLEL=false
+    return
+  fi
+
+  if [ "$script" = "$_BASHUNIT_PROVIDER_MAP_SCRIPT" ]; then
+    return
+  fi
+
+  _BASHUNIT_PROVIDER_MAP_SCRIPT="$script"
+  _BASHUNIT_PROVIDER_MAP_FNS=()
+  _BASHUNIT_PROVIDER_MAP_PROVIDERS=()
+  _BASHUNIT_PROVIDER_MAP_NO_PARALLEL=false
+
+  local count=0
+  local fn provider
+  # Single awk pass emits "<fn>\t<provider>" for every function whose
+  # definition is at most two lines below a `# @data_provider` (or
+  # `# data_provider`) annotation, mirroring the previous grep -B2 + sed.
+  # A reserved sentinel fn name carries the no-parallel-tests flag out of the
+  # single awk pass; real fn names are identifiers so they never collide.
+  while IFS=$'\t' read -r fn provider; do
+    [ -z "$fn" ] && continue
+    if [ "$fn" = "@@no_parallel@@" ]; then
+      [ "$provider" = "1" ] && _BASHUNIT_PROVIDER_MAP_NO_PARALLEL=true
+      continue
+    fi
+    _BASHUNIT_PROVIDER_MAP_FNS[count]="$fn"
+    _BASHUNIT_PROVIDER_MAP_PROVIDERS[count]="$provider"
+    count=$((count + 1))
+  done < <(awk '
+    /^# bashunit: no-parallel-tests/ { no_parallel = 1; next }
+    /^[[:space:]]*#[[:space:]]*@?data_provider[[:space:]]+/ {
+      p = $0
+      sub(/^[[:space:]]*#[[:space:]]*@?data_provider[[:space:]]+/, "", p)
+      sub(/[[:space:]]+$/, "", p)
+      pending = p
+      pending_line = NR
+      next
+    }
+    {
+      if (pending != "" && NR - pending_line <= 2) {
+        if (match($0, /^[[:space:]]*(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_:]*[[:space:]]*\(\)/)) {
+          fn = $0
+          sub(/^[[:space:]]*(function[[:space:]]+)?/, "", fn)
+          sub(/[[:space:]]*\(\).*/, "", fn)
+          printf "%s\t%s\n", fn, pending
+          pending = ""
+        }
+      } else if (pending != "" && NR - pending_line > 2) {
+        pending = ""
+      }
+    }
+    END { printf "@@no_parallel@@\t%d\n", no_parallel }
+  ' "$script" 2>/dev/null)
+}
+
+#
+# Pure-bash lookup against the cached provider map.
+# Writes the provider-function name (or empty) into _BASHUNIT_PROVIDER_FN_OUT.
+#
+# @param $1 string Test-function name
+#
+function bashunit::helper::provider_for_function() {
+  local function_name=$1
+  local i=0
+  local total=${#_BASHUNIT_PROVIDER_MAP_FNS[@]}
+  while [ "$i" -lt "$total" ]; do
+    if [ "${_BASHUNIT_PROVIDER_MAP_FNS[i]}" = "$function_name" ]; then
+      _BASHUNIT_PROVIDER_FN_OUT="${_BASHUNIT_PROVIDER_MAP_PROVIDERS[i]}"
+      return
+    fi
+    i=$((i + 1))
+  done
+  _BASHUNIT_PROVIDER_FN_OUT=""
 }
 
 function bashunit::helper::get_provider_data() {
   local function_name="$1"
   local script="$2"
 
-  # Handle directory changes in set_up_before_script (issue #529)
-  # If relative path doesn't exist, try with BASHUNIT_WORKING_DIR
-  if [ ! -f "$script" ] && [ -n "${BASHUNIT_WORKING_DIR:-}" ]; then
-    script="$BASHUNIT_WORKING_DIR/$script"
-  fi
+  bashunit::helper::build_provider_map "$script"
+  bashunit::helper::provider_for_function "$function_name"
 
-  if [ ! -f "$script" ]; then
-    return
-  fi
-
-  local data_provider_function
-  data_provider_function=$(
-    # shellcheck disable=SC1087
-    grep -B 2 -E "(function[[:space:]]+)?$function_name[[:space:]]*\(\)" "$script" 2>/dev/null |
-      sed -nE 's/^[[:space:]]*# *@?data_provider[[:space:]]+//p'
-  )
-
-  if [ -n "$data_provider_function" ]; then
-    bashunit::helper::execute_function_if_exists "$data_provider_function"
+  if [ -n "$_BASHUNIT_PROVIDER_FN_OUT" ]; then
+    bashunit::helper::execute_function_if_exists "$_BASHUNIT_PROVIDER_FN_OUT"
   fi
 }
 
@@ -5251,10 +5772,15 @@ function bashunit::helper::get_latest_tag() {
     head -n 1
 }
 
+# Also written by find_total_tests so a main-shell caller can read the count
+# without a $() capture (which would discard the provider-map cache built here).
+_BASHUNIT_HELPER_TOTAL_TESTS_OUT=0
+
 function bashunit::helper::find_total_tests() {
   local filter=${1:-}
   shift || true
 
+  _BASHUNIT_HELPER_TOTAL_TESTS_OUT=0
   if [ $# -eq 0 ]; then
     echo 0
     return
@@ -5268,12 +5794,18 @@ function bashunit::helper::find_total_tests() {
       continue
     fi
 
+    # Build the provider map in THIS shell before the counting subshell: the
+    # subshell inherits it (its own build call becomes a cache hit), and when
+    # the caller runs in the main shell the runner's later build for the same
+    # file is a cache hit too — one awk scan per file instead of two.
+    bashunit::helper::build_provider_map "$file"
+
     local file_count
     file_count=$( (
       # shellcheck source=/dev/null
       source "$file"
       local all_fn_names
-      all_fn_names=$(declare -F | awk '{print $3}')
+      all_fn_names=$(compgen -A function)
       local filtered_functions
       filtered_functions=$(bashunit::helper::get_functions_to_run "test" "$filter" "$all_fn_names") || true
 
@@ -5287,15 +5819,19 @@ function bashunit::helper::find_total_tests() {
         local -a provider_data=()
         local provider_data_count=0
         local fn_name line
+        # Scan once; functions without a provider count as 1 with no fork (#763).
+        bashunit::helper::build_provider_map "$file"
         for fn_name in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
-          provider_data=()
+          bashunit::helper::provider_for_function "$fn_name"
+          if [ -z "$_BASHUNIT_PROVIDER_FN_OUT" ]; then
+            count=$((count + 1))
+            continue
+          fi
           provider_data_count=0
           while IFS=" " read -r line; do
             [ -z "$line" ] && continue
-            # shellcheck disable=SC2034
-            provider_data[provider_data_count]="$line"
             provider_data_count=$((provider_data_count + 1))
-          done <<<"$(bashunit::helper::get_provider_data "$fn_name" "$file")"
+          done <<<"$(bashunit::helper::execute_function_if_exists "$_BASHUNIT_PROVIDER_FN_OUT")"
 
           if [ "$provider_data_count" -eq 0 ]; then
             count=$((count + 1))
@@ -5311,6 +5847,7 @@ function bashunit::helper::find_total_tests() {
     total_count=$((total_count + file_count))
   done
 
+  _BASHUNIT_HELPER_TOTAL_TESTS_OUT=$total_count
   echo "$total_count"
 }
 
@@ -5351,14 +5888,22 @@ function bashunit::helper::load_bench_files() {
 function bashunit::helper::get_function_line_number() {
   local fn_name=$1
 
-  shopt -s extdebug
-  local line_number
-  line_number=$(declare -F "$fn_name" | awk '{print $2}')
-  shopt -u extdebug
-
-  echo "$line_number"
+  # Enable extdebug only inside the subshell so the caller's setting is not
+  # clobbered. With extdebug, `declare -F` prints "<name> <line> <file>"; parse
+  # the line number with shell word-splitting instead of forking awk.
+  local declaration
+  declaration=$(
+    shopt -s extdebug
+    declare -F "$fn_name"
+  )
+  declaration="${declaration#* }"
+  echo "${declaration%% *}"
 }
 
+# Writes a sanitized, process-unique id into _BASHUNIT_HELPER_ID_OUT.
+# Return-slot form so the per-test caller avoids a $(...) capture fork (#764).
+# Arguments: $1 basename
+_BASHUNIT_HELPER_ID_OUT=""
 function bashunit::helper::generate_id() {
   local basename="$1"
   # Inline normalize_variable_name + random_str to avoid two forks per call.
@@ -5375,9 +5920,9 @@ function bashunit::helper::generate_id() {
     for ((_i = 0; _i < 6; _i++)); do
       _suffix="$_suffix${_chars:RANDOM%${#_chars}:1}"
     done
-    echo "${sanitized}_$$_${_suffix}"
+    _BASHUNIT_HELPER_ID_OUT="${sanitized}_$$_${_suffix}"
   else
-    echo "${sanitized}_$$"
+    _BASHUNIT_HELPER_ID_OUT="${sanitized}_$$"
   fi
 }
 
@@ -5464,9 +6009,104 @@ function bashunit::helper::find_function_at_line() {
   echo "$best_match"
 }
 
+# Tags map for the most recently scanned script. Mirrors the provider map
+# (build_provider_map): scanning a file once and caching each test-function ->
+# comma-separated tags pair replaces a per-test grep/sed backward walk with a
+# pure-bash lookup on the hot path when `--tag`/`--exclude-tag` is used (#773).
+_BASHUNIT_TAGS_MAP_SCRIPT=""
+_BASHUNIT_TAGS_MAP_FNS=()
+_BASHUNIT_TAGS_MAP_TAGS=()
+_BASHUNIT_TAGS_OUT=""
+
+#
+# Scans a script once and caches its test-function -> tags pairs.
+# Memoized by resolved path, so repeated calls for the same file do not rescan.
+#
+# @param $1 string Path to the test script
+#
+function bashunit::helper::build_tags_map() {
+  local script=$1
+  # Handle directory changes in set_up_before_script (issue #529)
+  if [ ! -f "$script" ] && [ -n "${BASHUNIT_WORKING_DIR:-}" ]; then
+    script="$BASHUNIT_WORKING_DIR/$script"
+  fi
+
+  if [ ! -f "$script" ]; then
+    # Unreadable path: reset to an empty map keyed to this argument so a
+    # follow-up lookup returns empty without rescanning.
+    _BASHUNIT_TAGS_MAP_SCRIPT="$1"
+    _BASHUNIT_TAGS_MAP_FNS=()
+    _BASHUNIT_TAGS_MAP_TAGS=()
+    return
+  fi
+
+  if [ "$script" = "$_BASHUNIT_TAGS_MAP_SCRIPT" ]; then
+    return
+  fi
+
+  _BASHUNIT_TAGS_MAP_SCRIPT="$script"
+  _BASHUNIT_TAGS_MAP_FNS=()
+  _BASHUNIT_TAGS_MAP_TAGS=()
+
+  local count=0
+  local fn tags
+  # Single awk pass emits "<fn>\t<tags>" for every function that carries at
+  # least one `# @tag <name>` comment in the contiguous comment block directly
+  # above its definition, mirroring the previous per-function backward walk.
+  # Tags accumulate nearest-to-the-function first (same order the old walk
+  # produced). A blank or non-comment line breaks the association; other
+  # comment lines keep the block open. Both `function test_x` and `test_x()`
+  # definition styles are recognised.
+  while IFS=$'\t' read -r fn tags; do
+    [ -z "$fn" ] && continue
+    _BASHUNIT_TAGS_MAP_FNS[count]="$fn"
+    _BASHUNIT_TAGS_MAP_TAGS[count]="$tags"
+    count=$((count + 1))
+  done < <(awk '
+    /^[[:space:]]*#[[:space:]]*@tag[[:space:]]/ {
+      t = $0
+      sub(/^[[:space:]]*#[[:space:]]*@tag[[:space:]]+/, "", t)
+      tags = (tags == "" ? t : t "," tags)
+      next
+    }
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_:]*[[:space:]]*\(\)/ {
+      fn = $0
+      sub(/^[[:space:]]*(function[[:space:]]+)?/, "", fn)
+      sub(/[[:space:]]*\(\).*/, "", fn)
+      if (tags != "") printf "%s\t%s\n", fn, tags
+      tags = ""
+      next
+    }
+    { tags = "" }
+  ' "$script" 2>/dev/null)
+}
+
+#
+# Pure-bash lookup against the cached tags map.
+# Writes the comma-separated tags (or empty) into _BASHUNIT_TAGS_OUT.
+#
+# @param $1 string Test-function name
+#
+function bashunit::helper::tags_for_function() {
+  local function_name=$1
+  local i=0
+  local total=${#_BASHUNIT_TAGS_MAP_FNS[@]}
+  while [ "$i" -lt "$total" ]; do
+    if [ "${_BASHUNIT_TAGS_MAP_FNS[i]}" = "$function_name" ]; then
+      _BASHUNIT_TAGS_OUT="${_BASHUNIT_TAGS_MAP_TAGS[i]}"
+      return
+    fi
+    i=$((i + 1))
+  done
+  _BASHUNIT_TAGS_OUT=""
+}
+
 #
 # Extracts @tag annotations for a specific function from a test file.
-# Looks for comment lines `# @tag <name>` immediately above the function definition.
+# Thin wrapper over the cached tags map, kept for callers that want the tags
+# on stdout. Hot-path call sites use build_tags_map + tags_for_function to
+# avoid the subshell fork.
 #
 # @param $1 string Function name
 # @param $2 string Script file path
@@ -5474,56 +6114,9 @@ function bashunit::helper::find_function_at_line() {
 # @return string Comma-separated list of tags, or empty if none
 #
 function bashunit::helper::get_tags_for_function() {
-  local function_name="$1"
-  local script="$2"
-
-  if [ ! -f "$script" ] && [ -n "${BASHUNIT_WORKING_DIR:-}" ]; then
-    script="$BASHUNIT_WORKING_DIR/$script"
-  fi
-
-  if [ ! -f "$script" ]; then
-    return
-  fi
-
-  # Find the line number of the function definition
-  local fn_line_num
-  fn_line_num=$(grep -n -E "(function[[:space:]]+)?${function_name}[[:space:]]*\(\)" "$script" 2>/dev/null | head -1)
-  if [ -z "$fn_line_num" ]; then
-    return
-  fi
-  fn_line_num="${fn_line_num%%:*}"
-
-  # Walk backwards from the line above the function, collecting @tag comments
-  local tags=""
-  local check_line=$((fn_line_num - 1))
-  while [ "$check_line" -ge 1 ]; do
-    local content
-    content=$(sed -n "${check_line}p" "$script")
-    local _re='^[[:space:]]*#[[:space:]]*@tag[[:space:]]'
-    if [ "$(echo "$content" | "$GREP" -cE "$_re" || true)" -gt 0 ]; then
-      local tag_name
-      tag_name=$(echo "$content" | sed -nE 's/^[[:space:]]*#[[:space:]]*@tag[[:space:]]+//p')
-      if [ -n "$tag_name" ]; then
-        if [ -z "$tags" ]; then
-          tags="$tag_name"
-        else
-          tags="$tags,$tag_name"
-        fi
-      fi
-    elif [ "$(echo "$content" | "$GREP" -cE '^[[:space:]]*#' || true)" -gt 0 ]; then
-      # Other comment line, keep walking
-      :
-    elif [ "$(echo "$content" | "$GREP" -cE '^[[:space:]]*$' || true)" -gt 0 ]; then
-      # Empty line, stop looking
-      break
-    else
-      # Non-comment, non-empty line, stop
-      break
-    fi
-    check_line=$((check_line - 1))
-  done
-
-  echo "$tags"
+  bashunit::helper::build_tags_map "$2"
+  bashunit::helper::tags_for_function "$1"
+  echo "$_BASHUNIT_TAGS_OUT"
 }
 
 #
@@ -5655,28 +6248,27 @@ function bashunit::watch::is_available() {
   elif bashunit::watch::_command_exists fswatch; then
     echo "fswatch"
   else
-    echo ""
+    echo "polling"
   fi
 }
 
 function bashunit::watch::run() {
   local path="${1:-.}"
   shift
-  local extra_args=("$@")
+  # Declare and assign separately: bash 3.0 does not expand a compound array
+  # assignment attached to `local`, it collapses "$@" into one literal element.
+  local extra_args
+  extra_args=("$@")
 
   local tool
   tool=$(bashunit::watch::is_available)
 
-  if [ -z "$tool" ]; then
-    printf "%sError: watch mode requires 'inotifywait' (Linux) or 'fswatch' (macOS).%s\n" \
-      "${_BASHUNIT_COLOR_FAILED}" "${_BASHUNIT_COLOR_DEFAULT}"
-    printf "  Linux:  sudo apt install inotify-tools\n"
-    printf "  macOS:  brew install fswatch\n"
-    exit 1
+  if [ "$tool" = "polling" ]; then
+    bashunit::watch::_print_polling_notice "$path"
+  else
+    printf "%sbashunit --watch%s  watching: %s\n\n" \
+      "${_BASHUNIT_COLOR_PASSED}" "${_BASHUNIT_COLOR_DEFAULT}" "$path"
   fi
-
-  printf "%sbashunit --watch%s  watching: %s\n\n" \
-    "${_BASHUNIT_COLOR_PASSED}" "${_BASHUNIT_COLOR_DEFAULT}" "$path"
 
   # Run once immediately before entering the watch loop
   bashunit::watch::run_tests "$path" "${extra_args[@]+"${extra_args[@]}"}"
@@ -5697,11 +6289,42 @@ function bashunit::watch::run_tests() {
   return $?
 }
 
+function bashunit::watch::_print_polling_notice() {
+  local path="$1"
+  printf "%sbashunit --watch%s  polling: %s (every %ss)\n\n" \
+    "${_BASHUNIT_COLOR_PASSED}" "${_BASHUNIT_COLOR_DEFAULT}" \
+    "$path" "${BASHUNIT_WATCH_INTERVAL:-2}"
+  printf "  No 'inotifywait' or 'fswatch' found; using pure-shell polling.\n"
+  printf "  Install one for instant triggers:\n"
+  printf "    Linux:  sudo apt install inotify-tools\n"
+  printf "    macOS:  brew install fswatch\n\n"
+}
+
+# Lists watched *.sh files modified since the sentinel file was touched.
+# Non-empty output means a rerun is due. `find -newer` is POSIX and avoids the
+# GNU/BSD `stat` flag divergence.
+function bashunit::watch::_poll_changes() {
+  local sentinel="$1"
+  local path="$2"
+  find "$path" -name '*.sh' -newer "$sentinel" -print 2>/dev/null
+}
+
 function bashunit::watch::wait_for_change() {
   local tool="$1"
   local path="$2"
 
   case "$tool" in
+  polling)
+    local sentinel
+    sentinel="$(bashunit::temp_dir watch)/sentinel"
+    while true; do
+      : >"$sentinel"
+      sleep "${BASHUNIT_WATCH_INTERVAL:-2}"
+      if [ -n "$(bashunit::watch::_poll_changes "$sentinel" "$path")" ]; then
+        return 0
+      fi
+    done
+    ;;
   inotifywait)
     inotifywait \
       --quiet \
@@ -5738,16 +6361,27 @@ function bashunit::assert::should_skip() {
   bashunit::env::is_stop_on_assertion_failure_enabled && ((_BASHUNIT_ASSERTION_FAILED_IN_TEST))
 }
 
-# Resolve assertion label: use custom label if provided, otherwise derive from test function name
-function bashunit::assert::label() {
+_BASHUNIT_ASSERT_LABEL_OUT=""
+
+# Resolve assertion label into the slot _BASHUNIT_ASSERT_LABEL_OUT with no fork:
+# use custom label if provided, otherwise derive from the test function name.
+# Must be called at the same stack depth as the echoing wrapper so the test-frame
+# fallback keeps resolving against the caller of the assertion.
+function bashunit::assert::label_to_slot() {
   local custom_label="${1:-}"
   if [ -n "$custom_label" ]; then
-    builtin echo "$custom_label"
+    _BASHUNIT_ASSERT_LABEL_OUT=$custom_label
     return
   fi
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  bashunit::helper::normalize_test_function_name "$test_fn"
+  bashunit::helper::find_test_function_name_to_slot
+  bashunit::helper::normalize_test_function_name_to_slot "$_BASHUNIT_HELPER_TESTFN_OUT"
+  _BASHUNIT_ASSERT_LABEL_OUT=$_BASHUNIT_HELPER_NORMALIZED_OUT
+}
+
+# Resolve assertion label: use custom label if provided, otherwise derive from test function name
+function bashunit::assert::label() {
+  bashunit::assert::label_to_slot "${1:-}"
+  builtin echo "$_BASHUNIT_ASSERT_LABEL_OUT"
 }
 
 function bashunit::fail() {
@@ -5755,10 +6389,9 @@ function bashunit::fail() {
 
   local message="${1:-${FUNCNAME[1]}}"
 
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+  bashunit::helper::find_test_function_name_to_slot
+  bashunit::helper::normalize_test_function_name_to_slot "$_BASHUNIT_HELPER_TESTFN_OUT"
+  local label=$_BASHUNIT_HELPER_NORMALIZED_OUT
   bashunit::assert::mark_failed
   bashunit::console_results::print_failure_message "${label}" "$message"
 }
@@ -5834,8 +6467,18 @@ function bashunit::run_command_or_eval() {
   eval\ * | eval)
     eval "${cmd#eval }" &>/dev/null
     ;;
+  *[=[:space:]]* | "")
+    # An alias name never contains "=" or whitespace, so this can't be an alias
+    # invocation: run it directly. Guarding here also stops `alias -- "$cmd"`
+    # below from *defining* an alias as a side effect when "$cmd" looks like
+    # "name=value" (which would wrongly succeed).
+    "$cmd" &>/dev/null
+    ;;
   *)
-    if [ "$(command -v "$cmd" | "$GREP" -cE '^alias' || true)" -gt 0 ]; then
+    # Detect aliases with the `alias` builtin instead of forking
+    # `command -v | grep`: it exits 0 only for a defined alias, matching the
+    # old `^alias` check for functions/binaries/unknown commands (all non-zero).
+    if alias -- "$cmd" >/dev/null 2>&1; then
       eval "$cmd" &>/dev/null
     else
       "$cmd" &>/dev/null
@@ -5848,10 +6491,9 @@ function bashunit::run_command_or_eval() {
 function bashunit::handle_bool_assertion_failure() {
   local expected="$1"
   local got="$2"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+  bashunit::helper::find_test_function_name_to_slot
+  bashunit::helper::normalize_test_function_name_to_slot "$_BASHUNIT_HELPER_TESTFN_OUT"
+  local label=$_BASHUNIT_HELPER_NORMALIZED_OUT
 
   bashunit::assert::mark_failed
   bashunit::console_results::print_failed_test "$label" "$expected" "but got " "$got"
@@ -5865,8 +6507,8 @@ function assert_same() {
   local label_override="${3:-}"
 
   if [ "$expected" != "$actual" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "but got " "${actual}"
     return
@@ -5882,14 +6524,14 @@ function assert_equals() {
   local actual="$2"
   local label_override="${3:-}"
 
-  local actual_cleaned
-  actual_cleaned=$(bashunit::str::strip_ansi "$actual")
-  local expected_cleaned
-  expected_cleaned=$(bashunit::str::strip_ansi "$expected")
+  bashunit::str::strip_ansi_to_slot "$actual"
+  local actual_cleaned=$_BASHUNIT_STR_STRIPPED_OUT
+  bashunit::str::strip_ansi_to_slot "$expected"
+  local expected_cleaned=$_BASHUNIT_STR_STRIPPED_OUT
 
   if [ "$expected_cleaned" != "$actual_cleaned" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected_cleaned}" "but got " "${actual_cleaned}"
     return
@@ -5905,14 +6547,14 @@ function assert_not_equals() {
   local actual="$2"
   local label_override="${3:-}"
 
-  local actual_cleaned
-  actual_cleaned=$(bashunit::str::strip_ansi "$actual")
-  local expected_cleaned
-  expected_cleaned=$(bashunit::str::strip_ansi "$expected")
+  bashunit::str::strip_ansi_to_slot "$actual"
+  local actual_cleaned=$_BASHUNIT_STR_STRIPPED_OUT
+  bashunit::str::strip_ansi_to_slot "$expected"
+  local expected_cleaned=$_BASHUNIT_STR_STRIPPED_OUT
 
   if [ "$expected_cleaned" = "$actual_cleaned" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected_cleaned}" "to not be" "${actual_cleaned}"
     return
@@ -5928,8 +6570,8 @@ function assert_empty() {
   local label_override="${2:-}"
 
   if [ "$expected" != "" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "to be empty" "but got " "${expected}"
     return
@@ -5945,8 +6587,8 @@ function assert_not_empty() {
   local label_override="${2:-}"
 
   if [ "$expected" = "" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "to not be empty" "but got " "${expected}"
     return
@@ -5963,8 +6605,8 @@ function assert_not_same() {
   local label_override="${3:-}"
 
   if [ "$expected" = "$actual" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to not be" "${actual}"
     return
@@ -5987,8 +6629,8 @@ function assert_contains() {
   case "$actual" in
   *"$expected"*) ;;
   *)
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to contain" "${expected}"
     return
@@ -6015,8 +6657,8 @@ function assert_contains_ignore_case() {
   case "$actual_lower" in
   *"$expected_lower"*) ;;
   *)
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to contain" "${expected}"
     return
@@ -6039,8 +6681,8 @@ function assert_not_contains() {
 
   case "$actual" in
   *"$expected"*)
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to not contain" "${expected}"
     return
@@ -6063,10 +6705,9 @@ function assert_matches() {
   if [ "$(printf '%s' "$actual" | "$GREP" -cE "$expected" || true)" -eq 0 ]; then
     # Retry with newlines collapsed for cross-line patterns
     if [ "$(printf '%s' "$actual" | tr '\n' ' ' | "$GREP" -cE "$expected" || true)" -eq 0 ]; then
-      local test_fn
-      test_fn="$(bashunit::helper::find_test_function_name)"
-      local label
-      label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+      bashunit::helper::find_test_function_name_to_slot
+      bashunit::helper::normalize_test_function_name_to_slot "$_BASHUNIT_HELPER_TESTFN_OUT"
+      local label=$_BASHUNIT_HELPER_NORMALIZED_OUT
       bashunit::assert::mark_failed
       bashunit::console_results::print_failed_test "${label}" "${actual}" "to match" "${expected}"
       return
@@ -6090,8 +6731,8 @@ function assert_not_matches() {
   # Check both line-by-line and with newlines collapsed for cross-line patterns
   if [ "$(printf '%s' "$actual" | "$GREP" -cE "$expected" || true)" -gt 0 ] ||
     [ "$(printf '%s' "$actual" | tr '\n' ' ' | "$GREP" -cE "$expected" || true)" -gt 0 ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to not match" "${expected}"
     return
@@ -6252,8 +6893,8 @@ function assert_exec() {
   fi
 
   if [ "$failed" -eq 1 ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "$label" "$expected_desc" "but got " "$actual_desc"
     return
@@ -6270,8 +6911,8 @@ function assert_exit_code() {
   local expected_exit_code="$1"
 
   if [ "$actual_exit_code" -ne "$expected_exit_code" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual_exit_code}" "to be" "${expected_exit_code}"
     return
@@ -6288,8 +6929,8 @@ function assert_successful_code() {
   local expected_exit_code=0
 
   if [ "$actual_exit_code" -ne "$expected_exit_code" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test \
       "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
@@ -6305,8 +6946,8 @@ function assert_unsuccessful_code() {
   bashunit::assert::should_skip && return 0
 
   if [ "$actual_exit_code" -eq 0 ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual_exit_code}" "to be non-zero" "but was 0"
     return
@@ -6323,8 +6964,8 @@ function assert_general_error() {
   local expected_exit_code=1
 
   if [ "$actual_exit_code" -ne "$expected_exit_code" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test \
       "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
@@ -6342,8 +6983,8 @@ function assert_command_not_found() {
   local expected_exit_code=127
 
   if [ "$actual_exit_code" -ne "$expected_exit_code" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test \
       "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
@@ -6367,8 +7008,8 @@ function assert_string_starts_with() {
   case "$actual" in
   "$expected"*) ;;
   *)
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to start with" "${expected}"
     return
@@ -6387,8 +7028,8 @@ function assert_string_not_starts_with() {
 
   case "$actual" in
   "$expected"*)
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to not start with" "${expected}"
     return
@@ -6412,8 +7053,8 @@ function assert_string_ends_with() {
   case "$actual" in
   *"$expected") ;;
   *)
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to end with" "${expected}"
     return
@@ -6436,8 +7077,8 @@ function assert_string_not_ends_with() {
 
   case "$actual" in
   *"$expected")
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to not end with" "${expected}"
     return
@@ -6455,8 +7096,8 @@ function assert_less_than() {
   local label_override="${3:-}"
 
   if ! [ "$actual" -lt "$expected" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be less than" "${expected}"
     return
@@ -6473,8 +7114,8 @@ function assert_less_or_equal_than() {
   local label_override="${3:-}"
 
   if ! [ "$actual" -le "$expected" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be less or equal than" "${expected}"
     return
@@ -6491,8 +7132,8 @@ function assert_greater_than() {
   local label_override="${3:-}"
 
   if ! [ "$actual" -gt "$expected" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be greater than" "${expected}"
     return
@@ -6509,8 +7150,8 @@ function assert_greater_or_equal_than() {
   local label_override="${3:-}"
 
   if ! [ "$actual" -ge "$expected" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be greater or equal than" "${expected}"
     return
@@ -6546,15 +7187,15 @@ function assert_within_delta() {
   local expected="$1"
   local actual="$2"
   local delta="$3"
-  local label
-  label="$(bashunit::assert::label)"
 
   if ! bashunit::assert::_is_numeric "$expected" ||
     ! bashunit::assert::_is_numeric "$actual" ||
     ! bashunit::assert::_is_numeric "$delta"; then
+    bashunit::assert::label_to_slot
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test \
-      "${label}" "${expected} ${actual} ${delta}" "to all be numeric" "but got a non-numeric value"
+      "${_BASHUNIT_ASSERT_LABEL_OUT}" "${expected} ${actual} ${delta}" \
+      "to all be numeric" "but got a non-numeric value"
     return
   fi
 
@@ -6565,9 +7206,10 @@ function assert_within_delta() {
   esac
 
   if [ "$(bashunit::math::calculate "$diff <= $delta")" != "1" ]; then
+    bashunit::assert::label_to_slot
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test \
-      "${label}" "${actual}" "to be within ${delta} of" "${expected}"
+      "${_BASHUNIT_ASSERT_LABEL_OUT}" "${actual}" "to be within ${delta} of" "${expected}"
     return
   fi
 
@@ -6604,8 +7246,8 @@ function assert_line_count() {
   fi
 
   if [ "$expected" != "$actual" ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
 
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${input_str}" \
@@ -6670,8 +7312,8 @@ function assert_string_matches_format() {
   regex="$(bashunit::format_to_regex "$format")"
 
   if [ "$(printf '%s' "$actual" | "$GREP" -cE "$regex" || true)" -eq 0 ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to match format" "${format}"
     return
@@ -6691,8 +7333,8 @@ function assert_string_not_matches_format() {
   regex="$(bashunit::format_to_regex "$format")"
 
   if [ "$(printf '%s' "$actual" | "$GREP" -cE "$regex" || true)" -gt 0 ]; then
-    local label
-    label="$(bashunit::assert::label "${label_override:-}")"
+    bashunit::assert::label_to_slot "${label_override:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to not match format" "${format}"
     return
@@ -7573,11 +8215,25 @@ function assert_json_equals() {
 # assert_snapshot.sh
 # shellcheck disable=SC2155
 
+# Strips all carriage returns, then any trailing newlines, entirely in bash.
+# Reproduces the previous `$(echo -n "$in" | tr -d '\r')` (command substitution
+# drops trailing newlines) without the two forks. Result in _snapshot_normalized.
+function bashunit::snapshot::normalize_actual() {
+  local normalized="${1//$'\r'/}"
+  while [ "${normalized%$'\n'}" != "$normalized" ]; do
+    normalized="${normalized%$'\n'}"
+  done
+  _snapshot_normalized=$normalized
+}
+
 function assert_match_snapshot() {
-  local actual=$(echo -n "$1" | tr -d '\r')
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local snapshot_file=$(bashunit::snapshot::resolve_file "${2:-}" "$test_fn")
+  local _snapshot_normalized
+  bashunit::snapshot::normalize_actual "$1"
+  local actual=$_snapshot_normalized
+  bashunit::helper::find_test_function_name_to_slot
+  local test_fn=$_BASHUNIT_HELPER_TESTFN_OUT
+  bashunit::snapshot::resolve_file "${2:-}" "$test_fn"
+  local snapshot_file=$_BASHUNIT_SNAPSHOT_FILE_OUT
 
   if [ ! -f "$snapshot_file" ]; then
     bashunit::snapshot::initialize "$snapshot_file" "$actual"
@@ -7588,10 +8244,21 @@ function assert_match_snapshot() {
 }
 
 function assert_match_snapshot_ignore_colors() {
-  local actual=$(echo -n "$1" | sed 's/\x1B\[[0-9;]*[mK]//g' | tr -d '\r')
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local snapshot_file=$(bashunit::snapshot::resolve_file "${2:-}" "$test_fn")
+  # Only fork sed when the input actually carries an escape sequence; plain,
+  # colorless output takes a pure-bash fast path. The sed pattern is kept
+  # identical to the historic one (strip `\x1B[...[mK]` only) so on-disk
+  # snapshots stay byte-compatible.
+  local stripped=$1
+  case "$stripped" in
+  *$'\e'*) stripped=$(printf '%s' "$stripped" | sed 's/\x1B\[[0-9;]*[mK]//g') ;;
+  esac
+  local _snapshot_normalized
+  bashunit::snapshot::normalize_actual "$stripped"
+  local actual=$_snapshot_normalized
+  bashunit::helper::find_test_function_name_to_slot
+  local test_fn=$_BASHUNIT_HELPER_TESTFN_OUT
+  bashunit::snapshot::resolve_file "${2:-}" "$test_fn"
+  local snapshot_file=$_BASHUNIT_SNAPSHOT_FILE_OUT
 
   if [ ! -f "$snapshot_file" ]; then
     bashunit::snapshot::initialize "$snapshot_file" "$actual"
@@ -7618,24 +8285,48 @@ function bashunit::snapshot::match_with_placeholder() {
       exit($input =~ /$r/s ? 0 : 1);
     ' && return 0 || return 1
   else
-    local fallback=$(printf '%s' "$snapshot" | sed -e "s|$placeholder|.*|g" -e 's/[][\.^$*+?{}|()]/\\&/g')
-    fallback="^${fallback}$"
+    # No perl: build the pattern exactly like the perl branch — swap the
+    # placeholder for a token that survives escaping, escape the regex
+    # metacharacters, then turn the token into `.*`. (The previous order,
+    # escaping after inserting `.*`, escaped the `.*` itself and broke every
+    # fallback match.) grep matches line-by-line, so unlike the perl branch a
+    # placeholder cannot span multiple lines here.
+    local fallback="${snapshot//$placeholder/$token}"
+    fallback=$(printf '%s' "$fallback" | sed -e 's/[.[\\^$*+?{}()|]/\\&/g')
+    fallback="^${fallback//$token/.*}$"
     echo "$actual" | grep -Eq "$fallback" && return 0 || return 1
   fi
 }
 
+# Writes the resolved snapshot path into _BASHUNIT_SNAPSHOT_FILE_OUT (no fork).
+# Derives the path from BASH_SOURCE[2] using parameter expansion instead of
+# dirname/basename, keeping the exact string the previous version produced.
+_BASHUNIT_SNAPSHOT_FILE_OUT=""
 function bashunit::snapshot::resolve_file() {
   local file_hint="$1"
   local func_name="$2"
 
   if [ -n "$file_hint" ]; then
-    echo "$file_hint"
-  else
-    local dir="./$(dirname "${BASH_SOURCE[2]}")/snapshots"
-    local test_file="$(bashunit::helper::normalize_variable_name "$(basename "${BASH_SOURCE[2]}")")"
-    local name="$(bashunit::helper::normalize_variable_name "$func_name").snapshot"
-    echo "${dir}/${test_file}.${name}"
+    _BASHUNIT_SNAPSHOT_FILE_OUT=$file_hint
+    return
   fi
+
+  # dirname via parameter expansion. `dirname "foo.sh"` (no slash) is ".", which
+  # `${src%/*}` cannot yield, so special-case the slashless path.
+  local src="${BASH_SOURCE[2]}"
+  local dir_part
+  case "$src" in
+  */*) dir_part="${src%/*}" ;;
+  *) dir_part="." ;;
+  esac
+  local base_part="${src##*/}"
+
+  bashunit::helper::normalize_variable_name_to_slot "$base_part"
+  local test_file=$_BASHUNIT_HELPER_VARNAME_OUT
+  bashunit::helper::normalize_variable_name_to_slot "$func_name"
+  local name="$_BASHUNIT_HELPER_VARNAME_OUT.snapshot"
+
+  _BASHUNIT_SNAPSHOT_FILE_OUT="./${dir_part}/snapshots/${test_file}.${name}"
 }
 
 function bashunit::snapshot::initialize() {
@@ -7651,8 +8342,12 @@ function bashunit::snapshot::compare() {
   local snapshot_path="$2"
   local func_name="$3"
 
+  # `$(<file)` reads without forking cat/tr; command substitution drops trailing
+  # newlines exactly like the previous `$(tr -d '\r' <file)`. Strip the carriage
+  # returns in bash afterwards.
   local snapshot
-  snapshot=$(tr -d '\r' <"$snapshot_path")
+  snapshot=$(<"$snapshot_path")
+  snapshot="${snapshot//$'\r'/}"
 
   if ! bashunit::snapshot::match_with_placeholder "$actual" "$snapshot"; then
     local label=$(bashunit::helper::normalize_test_function_name "$func_name")
@@ -7909,3825 +8604,6 @@ function assert_not_called() {
   local command=$1
   local label="${2:-$(bashunit::helper::normalize_test_function_name "${FUNCNAME[1]}")}"
   assert_have_been_called_times 0 "$command" "$label"
-}
-
-# reports.sh
-# shellcheck disable=SC2155
-
-_BASHUNIT_REPORTS_TEST_FILES=()
-_BASHUNIT_REPORTS_TEST_NAMES=()
-_BASHUNIT_REPORTS_TEST_STATUSES=()
-_BASHUNIT_REPORTS_TEST_DURATIONS=()
-_BASHUNIT_REPORTS_TEST_ASSERTIONS=()
-_BASHUNIT_REPORTS_TEST_FAILURES=()
-_BASHUNIT_REPORTS_TEST_LINES=()
-
-function bashunit::reports::add_test_snapshot() {
-  bashunit::reports::add_test "$1" "$2" "$3" "$4" "snapshot"
-}
-
-function bashunit::reports::add_test_incomplete() {
-  bashunit::reports::add_test "$1" "$2" "$3" "$4" "incomplete"
-}
-
-function bashunit::reports::add_test_skipped() {
-  bashunit::reports::add_test "$1" "$2" "$3" "$4" "skipped"
-}
-
-function bashunit::reports::add_test_passed() {
-  bashunit::reports::add_test "$1" "$2" "$3" "$4" "passed"
-}
-
-function bashunit::reports::add_test_risky() {
-  bashunit::reports::add_test "$1" "$2" "$3" "$4" "risky"
-}
-
-function bashunit::reports::add_test_failed() {
-  bashunit::reports::add_test "$1" "$2" "$3" "$4" "failed" "$5"
-}
-
-function bashunit::reports::add_test() {
-  # Skip tracking when no report output is requested
-  {
-    [ -n "${BASHUNIT_LOG_JUNIT:-}" ] ||
-      [ -n "${BASHUNIT_REPORT_HTML:-}" ] ||
-      [ -n "${BASHUNIT_LOG_GHA:-}" ] ||
-      [ -n "${BASHUNIT_REPORT_TAP:-}" ] ||
-      [ -n "${BASHUNIT_REPORT_JSON:-}" ]
-  } || return 0
-
-  local file="$1"
-  local test_name="$2"
-  local duration="$3"
-  local assertions="$4"
-  local status="$5"
-  local failure_message="${6:-}"
-
-  # Capture the line number from the current test location ("file:line"),
-  # but only when it belongs to this test's file, so a stale location from a
-  # prior test never mislabels this entry.
-  local line=""
-  case "${_BASHUNIT_TEST_LOCATION:-}" in
-    "$file":*) line="${_BASHUNIT_TEST_LOCATION##*:}" ;;
-  esac
-
-  _BASHUNIT_REPORTS_TEST_FILES[${#_BASHUNIT_REPORTS_TEST_FILES[@]}]="$file"
-  _BASHUNIT_REPORTS_TEST_NAMES[${#_BASHUNIT_REPORTS_TEST_NAMES[@]}]="$test_name"
-  _BASHUNIT_REPORTS_TEST_STATUSES[${#_BASHUNIT_REPORTS_TEST_STATUSES[@]}]="$status"
-  _BASHUNIT_REPORTS_TEST_ASSERTIONS[${#_BASHUNIT_REPORTS_TEST_ASSERTIONS[@]}]="$assertions"
-  _BASHUNIT_REPORTS_TEST_DURATIONS[${#_BASHUNIT_REPORTS_TEST_DURATIONS[@]}]="$duration"
-  _BASHUNIT_REPORTS_TEST_FAILURES[${#_BASHUNIT_REPORTS_TEST_FAILURES[@]}]="$failure_message"
-  _BASHUNIT_REPORTS_TEST_LINES[${#_BASHUNIT_REPORTS_TEST_LINES[@]}]="$line"
-}
-
-function bashunit::reports::__xml_escape() {
-  local text="$1"
-  # Strip ANSI escape sequences and control characters invalid in XML 1.0,
-  # then escape XML special characters (& first to avoid double-escaping)
-  echo "$text" \
-    | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
-    | tr -d '\000-\010\013\014\016-\037' \
-    | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
-}
-
-# Escapes a string for embedding in a JSON string literal (pure Bash, no jq).
-# Strips ANSI/control chars that cannot appear inline, keeps \t\r\n as escapes.
-function bashunit::reports::__json_escape() {
-  local text="$1"
-  text=$(printf '%s' "$text" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' | tr -d '\000-\010\013\014\016-\037')
-  # Backslash first so escapes added below are not doubled.
-  text="${text//\\/\\\\}"
-  text="${text//\"/\\\"}"
-  text="${text//$'\t'/\\t}"
-  text="${text//$'\r'/\\r}"
-  text="${text//$'\n'/\\n}"
-  printf '%s' "$text"
-}
-
-function bashunit::reports::generate_junit_xml() {
-  local output_file="$1"
-
-  local tests_skipped=$(bashunit::state::get_tests_skipped)
-  local tests_incomplete=$(bashunit::state::get_tests_incomplete)
-  local tests_failed=$(bashunit::state::get_tests_failed)
-  local time_ms=$(bashunit::clock::total_runtime_in_milliseconds)
-  local time
-  time=$(LC_ALL=C awk -v ms="$time_ms" 'BEGIN {printf "%.3f", ms/1000}')
-
-  {
-    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    echo "<testsuites>"
-    echo "  <testsuite name=\"bashunit\" tests=\"${#_BASHUNIT_REPORTS_TEST_NAMES[@]}\""
-    echo "             failures=\"$tests_failed\" errors=\"0\""
-    echo "             skipped=\"$(( tests_skipped + tests_incomplete ))\""
-    echo "             time=\"$time\">"
-
-    local i
-    for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
-      local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
-      local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
-      local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
-      local test_time_ms="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-}"
-      local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
-      local test_time
-      test_time=$(LC_ALL=C awk -v ms="$test_time_ms" 'BEGIN {printf "%.3f", ms/1000}')
-
-      echo "    <testcase file=\"$file\""
-      echo "        name=\"$name\""
-      echo "        time=\"$test_time\">"
-
-      # Add failure element for failed tests with actual failure message
-      if [ "$status" = "failed" ]; then
-        local escaped_message
-        escaped_message=$(bashunit::reports::__xml_escape "$failure_message")
-        echo "      <failure message=\"Test failed\">$escaped_message</failure>"
-      elif [ "$status" = "risky" ]; then
-        echo "      <skipped message=\"Test has no assertions (risky)\"/>"
-      elif [ "$status" = "skipped" ]; then
-        echo "      <skipped/>"
-      elif [ "$status" = "incomplete" ]; then
-        echo "      <skipped message=\"Test incomplete\"/>"
-      fi
-
-      echo "    </testcase>"
-    done
-
-    echo "  </testsuite>"
-    echo "</testsuites>"
-  } >"$output_file"
-}
-
-##
-# Prepares a failure message for a TAP YAML diagnostic block: strips ANSI escape
-# sequences, collapses newlines to spaces and doubles single quotes so the value
-# is safe inside a YAML single-quoted scalar. Bash 3.0+ compatible.
-##
-function bashunit::reports::__tap_message() {
-  echo "$1" \
-    | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
-    | tr '\n' ' ' \
-    | sed -e "s/'/''/g"
-}
-
-##
-# Writes results in TAP version 13 format (https://testanything.org).
-# Passing/snapshot -> "ok", failed -> "not ok" with a YAML diagnostic,
-# skipped/risky -> "# SKIP", incomplete -> "# TODO".
-# Arguments: $1 - output file
-##
-function bashunit::reports::generate_report_tap() {
-  local output_file="$1"
-  local total="${#_BASHUNIT_REPORTS_TEST_NAMES[@]}"
-
-  {
-    echo "TAP version 13"
-    echo "1..$total"
-
-    local i seq=0
-    for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
-      seq=$((seq + 1))
-      local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
-      local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
-      local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
-
-      case "$status" in
-      failed)
-        echo "not ok $seq - $name"
-        echo "  ---"
-        echo "  message: '$(bashunit::reports::__tap_message "$failure_message")'"
-        echo "  ..."
-        ;;
-      skipped)
-        echo "ok $seq - $name # SKIP"
-        ;;
-      risky)
-        echo "ok $seq - $name # SKIP risky (no assertions)"
-        ;;
-      incomplete)
-        echo "ok $seq - $name # TODO"
-        ;;
-      *)
-        echo "ok $seq - $name"
-        ;;
-      esac
-    done
-  } >"$output_file"
-}
-
-function bashunit::reports::generate_report_json() {
-  local output_file="$1"
-  local total="${#_BASHUNIT_REPORTS_TEST_NAMES[@]}"
-
-  local passed=0 failed=0 skipped=0 incomplete=0 duration_total=0
-  local i
-  for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
-    duration_total=$((duration_total + ${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-0}))
-    case "${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}" in
-    failed) failed=$((failed + 1)) ;;
-    skipped) skipped=$((skipped + 1)) ;;
-    incomplete) incomplete=$((incomplete + 1)) ;;
-    # snapshot and risky ran without failing, so they count as passed here; the
-    # per-test "status" field below preserves the exact category.
-    *) passed=$((passed + 1)) ;;
-    esac
-  done
-
-  {
-    printf '{\n'
-    printf '  "summary": { "total": %d, "passed": %d, "failed": %d,' \
-      "$total" "$passed" "$failed"
-    printf ' "skipped": %d, "incomplete": %d, "duration_ms": %d },\n' \
-      "$skipped" "$incomplete" "$duration_total"
-    printf '  "tests": [\n'
-    local seq=0
-    for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
-      local file name status duration message sep
-      file=$(bashunit::reports::__json_escape "${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}")
-      name=$(bashunit::reports::__json_escape "${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}")
-      status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
-      duration="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-0}"
-      message=$(bashunit::reports::__json_escape "${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}")
-      sep=","
-      [ "$seq" -eq "$((total - 1))" ] && sep=""
-      printf '    { "file": "%s", "name": "%s", "status": "%s", "duration_ms": %d, "message": "%s" }%s\n' \
-        "$file" "$name" "$status" "$duration" "$message" "$sep"
-      seq=$((seq + 1))
-    done
-    printf '  ]\n'
-    printf '}\n'
-  } >"$output_file"
-}
-
-function bashunit::reports::__gha_encode() {
-  local text="$1"
-  # Strip ANSI escape sequences first (one sed call)
-  text=$(printf '%s' "$text" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g')
-  # Percent-encode reserved chars per GHA workflow-commands spec.
-  # Bash 3.0+ parameter expansion avoids extra awk/sed calls.
-  # Order matters: encode '%' first so the sequences we inject stay literal.
-  text="${text//%/%25}"
-  text="${text//$'\r'/%0D}"
-  text="${text//$'\n'/%0A}"
-  printf '%s' "$text"
-}
-
-# Echoes GitHub Actions workflow-command annotations to stdout.
-# Arguments: $1 - "failed-only" to emit just errors (default: all reportable).
-function bashunit::reports::print_gha_annotations() {
-  local only="${1:-all}"
-
-  local i
-  for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
-    local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
-    local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
-    local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
-    local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
-    local line="${_BASHUNIT_REPORTS_TEST_LINES[$i]:-}"
-    local level="" message=""
-
-    case "$status" in
-      failed)
-        level="error"
-        message="$failure_message"
-        ;;
-      risky)
-        level="warning"
-        message="Test has no assertions (risky)"
-        ;;
-      incomplete)
-        level="notice"
-        message="Test incomplete"
-        ;;
-      *)
-        continue
-        ;;
-    esac
-
-    if [ "$only" = "failed-only" ] && [ "$status" != "failed" ]; then
-      continue
-    fi
-
-    local location="file=${file}"
-    if [ -n "$line" ]; then
-      location="${location},line=${line}"
-    fi
-
-    local encoded_message
-    encoded_message=$(bashunit::reports::__gha_encode "$message")
-    echo "::${level} ${location},title=${name}::${encoded_message}"
-  done
-}
-
-function bashunit::reports::generate_gha_log() {
-  local output_file="$1"
-
-  bashunit::reports::print_gha_annotations all >"$output_file"
-}
-
-function bashunit::reports::generate_report_html() {
-  local output_file="$1"
-
-  local test_passed=$(bashunit::state::get_tests_passed)
-  local tests_skipped=$(bashunit::state::get_tests_skipped)
-  local tests_incomplete=$(bashunit::state::get_tests_incomplete)
-  local tests_snapshot=$(bashunit::state::get_tests_snapshot)
-  local tests_failed=$(bashunit::state::get_tests_failed)
-  local time=$(bashunit::clock::total_runtime_in_milliseconds)
-
-  # Temporary file to store test cases by file (use mktemp for parallel safety)
-  local temp_file
-  temp_file=$(mktemp "${TMPDIR:-/tmp}/bashunit-report.XXXXXX")
-
-  # Collect test cases by file
-  : >"$temp_file" # Clear temp file if it exists
-  local i
-  for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
-    local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
-    local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
-    local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
-    local test_time="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-}"
-    local test_case="$file|$name|$status|$test_time"
-
-    echo "$test_case" >>"$temp_file"
-  done
-
-  {
-    echo "<!DOCTYPE html>"
-    echo "<html lang=\"en\">"
-    echo "<head>"
-    echo "  <meta charset=\"UTF-8\">"
-    echo "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
-    echo "  <title>Test Report</title>"
-    echo "  <style>"
-    echo "    body { font-family: Arial, sans-serif; }"
-    echo "    table { width: 100%; border-collapse: collapse; }"
-    echo "    th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }"
-    echo "    th { background-color: #f2f2f2; }"
-    echo "    .passed { background-color: #dff0d8; }"
-    echo "    .failed { background-color: #f2dede; }"
-    echo "    .skipped { background-color: #fcf8e3; }"
-    echo "    .incomplete { background-color: #d9edf7; }"
-    echo "    .snapshot { background-color: #dfe6e9; }"
-    echo "    .risky { background-color: #f5e6f5; }"
-    echo "  </style>"
-    echo "</head>"
-    echo "<body>"
-    echo "  <h1>Test Report</h1>"
-    echo "  <table>"
-    echo "    <thead>"
-    echo "      <tr>"
-    echo "        <th>Total Tests</th>"
-    echo "        <th>Passed</th>"
-    echo "        <th>Failed</th>"
-    echo "        <th>Incomplete</th>"
-    echo "        <th>Skipped</th>"
-    echo "        <th>Snapshot</th>"
-    echo "        <th>Time (ms)</th>"
-    echo "      </tr>"
-    echo "    </thead>"
-    echo "    <tbody>"
-    echo "      <tr>"
-    echo "        <td>${#_BASHUNIT_REPORTS_TEST_NAMES[@]}</td>"
-    echo "        <td>$test_passed</td>"
-    echo "        <td>$tests_failed</td>"
-    echo "        <td>$tests_incomplete</td>"
-    echo "        <td>$tests_skipped</td>"
-    echo "        <td>$tests_snapshot</td>"
-    echo "        <td>$time</td>"
-    echo "      </tr>"
-    echo "    </tbody>"
-    echo "  </table>"
-    echo "  <p>Time: $time ms</p>"
-
-    # Read the temporary file and group by file
-    local current_file=""
-    local file name status test_time
-    while IFS='|' read -r file name status test_time; do
-      if [ "$file" != "$current_file" ]; then
-        if [ -n "$current_file" ]; then
-          echo "    </tbody>"
-          echo "  </table>"
-        fi
-        echo "  <h2>File: $file</h2>"
-        echo "  <table>"
-        echo "    <thead>"
-        echo "      <tr>"
-        echo "        <th>Test Name</th>"
-        echo "        <th>Status</th>"
-        echo "        <th>Time (ms)</th>"
-        echo "      </tr>"
-        echo "    </thead>"
-        echo "    <tbody>"
-        current_file="$file"
-      fi
-      echo "      <tr class=\"$status\">"
-      echo "        <td>$name</td>"
-      echo "        <td>$status</td>"
-      echo "        <td>$test_time</td>"
-      echo "      </tr>"
-    done <"$temp_file"
-
-    # Close the last table
-    if [ -n "$current_file" ]; then
-      echo "    </tbody>"
-      echo "  </table>"
-    fi
-
-    echo "</body>"
-    echo "</html>"
-  } >"$output_file"
-
-  # Clean up temporary file
-  rm -f "$temp_file"
-}
-
-# runner.sh
-# shellcheck disable=SC2155
-
-# Pre-compiled regex pattern for parsing test result assertions
-if [ -z "${_BASHUNIT_RUNNER_PARSE_RESULT_REGEX+x}" ]; then
-  declare -r _BASHUNIT_RUNNER_PARSE_RESULT_REGEX='ASSERTIONS_FAILED=([0-9]*)##'\
-'ASSERTIONS_PASSED=([0-9]*)##ASSERTIONS_SKIPPED=([0-9]*)##'\
-'ASSERTIONS_INCOMPLETE=([0-9]*)##ASSERTIONS_SNAPSHOT=([0-9]*)##TEST_EXIT_CODE=([0-9]*)'
-fi
-
-function bashunit::runner::restore_workdir() {
-  cd "$BASHUNIT_WORKING_DIR" 2>/dev/null || true
-}
-
-##
-# Whether the running Bash has a reliable `set -o pipefail`. Bash 3.0 shipped a
-# broken pipefail (a failing pipeline can wrongly report success), which makes
-# `--strict` unsound; on 3.0 we fall back to `set -eu` without pipefail.
-# Returns: 0 when pipefail is reliable (Bash >= 3.1), 1 otherwise.
-##
-function bashunit::runner::_supports_reliable_pipefail() {
-  if [ "${BASH_VERSINFO[0]:-0}" -gt 3 ]; then
-    return 0
-  fi
-  [ "${BASH_VERSINFO[0]:-0}" -eq 3 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 1 ]
-}
-
-# Caches BASHUNIT_COVERAGE into _BASHUNIT_COVERAGE_ON ("1"|"0") so hot-path checks
-# avoid a function dispatch per call. Call once after arg parsing; tests that
-# toggle BASHUNIT_COVERAGE mid-run must call this again to refresh.
-function bashunit::runner::sync_coverage_flag() {
-  if [ "${BASHUNIT_COVERAGE-}" = "true" ]; then
-    _BASHUNIT_COVERAGE_ON=1
-  else
-    _BASHUNIT_COVERAGE_ON=0
-  fi
-}
-
-function bashunit::runner::source_login_shell_profiles() {
-  # shellcheck disable=SC1091
-  [ -f /etc/profile ] && source /etc/profile 2>/dev/null || true
-  # shellcheck disable=SC1090
-  [ -f ~/.bash_profile ] && source ~/.bash_profile 2>/dev/null || true
-  # shellcheck disable=SC1090
-  [ -f ~/.bash_login ] && source ~/.bash_login 2>/dev/null || true
-  # shellcheck disable=SC1090
-  [ -f ~/.profile ] && source ~/.profile 2>/dev/null || true
-}
-
-function bashunit::runner::export_test_identity() {
-  local test_file=$1
-  local fn_name=$2
-  export BASHUNIT_CURRENT_TEST_ID="$(bashunit::helper::generate_id "$fn_name")"
-  bashunit::runner::resolve_test_location "$test_file" "$fn_name"
-  export _BASHUNIT_TEST_LOCATION
-  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
-    export _BASHUNIT_COVERAGE_CURRENT_TEST_FILE="$test_file"
-    export _BASHUNIT_COVERAGE_CURRENT_TEST_FN="$fn_name"
-  fi
-}
-
-##
-# Resolves "<test_file>:<line>" for a test function and writes it into the
-# global _BASHUNIT_TEST_LOCATION, using `declare -F` under `extdebug` to read
-# the definition line. Falls back to just the file path when the line cannot be
-# determined. Bash 3.0+ compatible. Writes a global slot (no extra subshell).
-# Arguments: $1 test file, $2 function name
-##
-function bashunit::runner::resolve_test_location() {
-  local test_file=$1
-  local fn_name=$2
-
-  # Enable extdebug only inside the command-substitution subshell so it never
-  # leaks into the parent shell — globally toggling extdebug interferes with
-  # `set -e`/DEBUG-trap behavior under --strict.
-  local def line=""
-  def="$(shopt -s extdebug; declare -F "$fn_name" 2>/dev/null)" || true
-
-  # `declare -F` (with extdebug) prints "<name> <line> <file>".
-  if [ -n "$def" ]; then
-    line=${def#* }
-    line=${line%% *}
-  fi
-
-  if [ -n "$line" ]; then
-    _BASHUNIT_TEST_LOCATION="${test_file}:${line}"
-  else
-    _BASHUNIT_TEST_LOCATION="$test_file"
-  fi
-}
-
-# Writes the interpolated test-function name into _BASHUNIT_RUNNER_INTERP_OUT.
-# Arguments: $1 fn_name, $@ test arguments
-function bashunit::runner::apply_interpolated_title() {
-  local fn_name=$1
-  shift
-
-  # Only "::N::"-style names interpolate; skip the capture fork for the rest.
-  case "$fn_name" in
-  *::*) ;;
-  *)
-    bashunit::state::reset_current_test_interpolated_function_name
-    _BASHUNIT_RUNNER_INTERP_OUT=$fn_name
-    return
-    ;;
-  esac
-
-  local interpolated
-  interpolated="$(bashunit::helper::interpolate_function_name "$fn_name" "$@")"
-  if [ "$interpolated" != "$fn_name" ]; then
-    bashunit::state::set_current_test_interpolated_function_name "$interpolated"
-  else
-    bashunit::state::reset_current_test_interpolated_function_name
-  fi
-  _BASHUNIT_RUNNER_INTERP_OUT=$interpolated
-}
-
-# Hot-path result helpers below return their value via a dedicated global slot
-# (`_BASHUNIT_RUNNER_*_OUT`) instead of stdout. This avoids the per-test
-# `$(...)` subshell capture that dominated the result-parsing hot path. Callers
-# invoke the helper and immediately read the slot:
-#
-#   bashunit::runner::extract_subshell_type "$subshell_output"
-#   type=$_BASHUNIT_RUNNER_TYPE_OUT
-#
-# A dedicated slot per helper (rather than one shared slot) means nested or
-# adjacent calls cannot clobber each other and callers don't need to copy out
-# before every other helper runs.
-_BASHUNIT_RUNNER_FIELD_OUT=""
-_BASHUNIT_RUNNER_TOTAL_OUT=""
-_BASHUNIT_RUNNER_TYPE_OUT=""
-_BASHUNIT_RUNNER_OUTPUT_OUT=""
-_BASHUNIT_RUNNER_INTERP_OUT=""
-_BASHUNIT_RUNNER_COUNTS_FAILED_OUT=0
-_BASHUNIT_RUNNER_COUNTS_PASSED_OUT=0
-_BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT=0
-_BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT=0
-_BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT=0
-_BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT=0
-# Suffix appended to a passed-test line when it only passed after retrying.
-_BASHUNIT_RETRY_NOTE=""
-
-# Writes the value of an encoded field (##KEY=value##) into _BASHUNIT_RUNNER_FIELD_OUT.
-# Arguments: $1 test_execution_result, $2 key
-function bashunit::runner::extract_encoded_field() {
-  local test_execution_result=$1
-  local key=$2
-  local marker="##${key}="
-  case "$test_execution_result" in
-  *"$marker"*)
-    local rest="${test_execution_result#*"$marker"}"
-    _BASHUNIT_RUNNER_FIELD_OUT="${rest%%##*}"
-    ;;
-  *) _BASHUNIT_RUNNER_FIELD_OUT="" ;;
-  esac
-}
-
-# Writes the sum of all ASSERTIONS_* counters into _BASHUNIT_RUNNER_TOTAL_OUT.
-# Arguments: $1 test_execution_result
-function bashunit::runner::compute_total_assertions() {
-  local test_execution_result=$1
-  local failed passed skipped incomplete snapshot
-  failed="${test_execution_result##*##ASSERTIONS_FAILED=}"
-  failed="${failed%%##*}"
-  passed="${test_execution_result##*##ASSERTIONS_PASSED=}"
-  passed="${passed%%##*}"
-  skipped="${test_execution_result##*##ASSERTIONS_SKIPPED=}"
-  skipped="${skipped%%##*}"
-  incomplete="${test_execution_result##*##ASSERTIONS_INCOMPLETE=}"
-  incomplete="${incomplete%%##*}"
-  snapshot="${test_execution_result##*##ASSERTIONS_SNAPSHOT=}"
-  snapshot="${snapshot%%##*}"
-  local total
-  total=$((${failed:-0} + ${passed:-0} + ${skipped:-0}))
-  total=$((total + ${incomplete:-0} + ${snapshot:-0}))
-  _BASHUNIT_RUNNER_TOTAL_OUT=$total
-}
-
-# Writes the subshell type marker (text inside leading [...]) into _BASHUNIT_RUNNER_TYPE_OUT.
-# Arguments: $1 subshell_output
-function bashunit::runner::extract_subshell_type() {
-  local subshell_output=$1
-  local type="${subshell_output%%]*}"
-  _BASHUNIT_RUNNER_TYPE_OUT="${type#[}"
-}
-
-# Writes the subshell output (minus the leading [type] marker, with embedded
-# status markers replaced by newlines) into _BASHUNIT_RUNNER_OUTPUT_OUT.
-# Arguments: $1 subshell_output
-function bashunit::runner::format_subshell_output() {
-  local subshell_output=$1
-  local line="${subshell_output#*]}"
-  line=${line//\[failed\]/$'\n'}
-  line=${line//\[skipped\]/$'\n'}
-  line=${line//\[incomplete\]/$'\n'}
-  _BASHUNIT_RUNNER_OUTPUT_OUT=$line
-}
-
-##
-# Appends a profiling record (duration, test name, file) to PROFILE_OUTPUT_PATH.
-# Uses a tab-separated, append-only line so it aggregates correctly across the
-# subshells spawned by parallel runs.
-# Arguments: $1 duration (ms), $2 test name, $3 test file
-##
-function bashunit::runner::record_profile() {
-  local duration=$1
-  local test_name=$2
-  local test_file=$3
-  printf '%s\t%s\t%s\n' "$duration" "$test_name" "$test_file" >>"$PROFILE_OUTPUT_PATH"
-}
-
-function bashunit::runner::detect_runtime_error() {
-  local runtime_output=$1
-  case "$runtime_output" in
-  *"command not found"* | *"unbound variable"* | *"permission denied"* | \
-    *"no such file or directory"* | *"syntax error"* | *"bad substitution"* | \
-    *"division by 0"* | *"cannot allocate memory"* | *"bad file descriptor"* | \
-    *"segmentation fault"* | *"illegal option"* | *"argument list too long"* | \
-    *"readonly variable"* | *"missing keyword"* | *"killed"* | \
-    *"cannot execute binary file"* | *"invalid arithmetic operator"* | \
-    *"ambiguous redirect"* | *"integer expression expected"* | \
-    *"too many arguments"* | *"value too great"* | \
-    *"not a valid identifier"* | *"unexpected EOF"*)
-    local runtime_error="${runtime_output#*: }"
-    printf '%s' "${runtime_error//$'\n'/}"
-    return 0
-    ;;
-  esac
-  printf ''
-}
-
-##
-# Maps a process exit code to a human-readable description when it indicates the
-# test was killed by a signal (128 + signal) or timed out. Returns an empty
-# string for ordinary exit codes. Bash 3.0+ compatible.
-# Arguments: $1 exit code
-##
-function bashunit::runner::classify_kill_signal() {
-  local code=$1
-
-  case "$code" in
-  124) printf 'Timed out (killed by `timeout`)' ;;
-  130) printf 'Interrupted (SIGINT)' ;;
-  137) printf 'Killed (SIGKILL — out of memory or forced termination)' ;;
-  143) printf 'Terminated (SIGTERM — e.g. a timeout)' ;;
-  *)
-    # Generic "killed by signal N" for other 128+N codes (signals 1..64)
-    case "$code" in
-    '' | *[!0-9]*) return 0 ;;
-    esac
-    if [ "$code" -gt 128 ] && [ "$code" -le 192 ]; then
-      printf 'Killed by signal %s' "$((code - 128))"
-    fi
-    ;;
-  esac
-}
-
-function bashunit::runner::print_verbose_test_summary() {
-  local test_file=$1
-  local fn_name=$2
-  local duration=$3
-  local test_execution_result=$4
-
-  if bashunit::env::is_simple_output_enabled; then
-    echo ""
-  fi
-
-  printf '%*s\n' "$TERMINAL_WIDTH" '' | tr ' ' '='
-  printf "%s\n" "File:     $test_file"
-  printf "%s\n" "Function: $fn_name"
-  printf "%s\n" "Duration: $duration ms"
-  local raw_text=${test_execution_result%%##ASSERTIONS_*}
-  [ -n "$raw_text" ] && printf "%s" "Raw text: $raw_text"
-  printf "%s\n" "##ASSERTIONS_${test_execution_result#*##ASSERTIONS_}"
-  printf '%*s\n' "$TERMINAL_WIDTH" '' | tr ' ' '-'
-}
-
-# Returns 0 when this Bash supports `wait -n` (Bash 4.3+), 1 otherwise.
-function bashunit::runner::_supports_wait_n() {
-  local major="${BASH_VERSINFO[0]:-0}"
-  local minor="${BASH_VERSINFO[1]:-0}"
-  if [ "$major" -gt 4 ]; then
-    return 0
-  fi
-  if [ "$major" -eq 4 ] && [ "$minor" -ge 3 ]; then
-    return 0
-  fi
-  return 1
-}
-
-function bashunit::runner::wait_for_job_slot() {
-  local max_jobs="${BASHUNIT_PARALLEL_JOBS:-0}"
-  if [ "$max_jobs" -le 0 ]; then
-    return 0
-  fi
-
-  if bashunit::runner::_supports_wait_n; then
-    # Bash 4.3+: block until any child exits. No polling, no sleep latency.
-    while [ "$(jobs -r | wc -l)" -ge "$max_jobs" ]; do
-      wait -n 2>/dev/null || break
-    done
-    return 0
-  fi
-
-  # Bash 3.x fallback: adaptive poll starting at 50ms, growing to 200ms to
-  # reduce `jobs -r` overhead on long-running tests while staying responsive.
-  local delay="0.05"
-  local iterations=0
-  while true; do
-    local running_jobs
-    running_jobs=$(jobs -r | wc -l)
-    if [ "$running_jobs" -lt "$max_jobs" ]; then
-      break
-    fi
-    sleep "$delay"
-    iterations=$((iterations + 1))
-    if [ "$iterations" -eq 4 ]; then
-      delay="0.1"
-    elif [ "$iterations" -eq 20 ]; then
-      delay="0.2"
-    fi
-  done
-}
-
-function bashunit::runner::load_test_files() {
-  local filter=$1
-  local tag_filter="${2:-}"
-  local exclude_tag_filter="${3:-}"
-  shift 3
-  local IFS=$' \t\n'
-  local -a files
-  files=("$@")
-  local -a scripts_ids=()
-  local scripts_ids_count=0
-
-  # Randomize file execution order (deterministic for the resolved seed).
-  if bashunit::env::is_random_order_enabled; then
-    local -a _shuffled_files=()
-    local _sf
-    while IFS= read -r _sf; do
-      [ -n "$_sf" ] && _shuffled_files[${#_shuffled_files[@]}]=$_sf
-    done < <(printf '%s\n' "${files[@]+"${files[@]}"}" | bashunit::math::shuffle "$(bashunit::env::seed)")
-    files=("${_shuffled_files[@]+"${_shuffled_files[@]}"}")
-  fi
-
-  bashunit::runner::sync_coverage_flag
-
-  # Initialize coverage tracking if enabled
-  if [ "$_BASHUNIT_COVERAGE_ON" = 1 ]; then
-    # Auto-discover coverage paths if not explicitly set
-    if [ -z "$BASHUNIT_COVERAGE_PATHS" ]; then
-      BASHUNIT_COVERAGE_PATHS=$(bashunit::coverage::auto_discover_paths "${files[@]}")
-      # Fallback: if auto-discovery yields no paths, track the src/ folder
-      if [ -z "$BASHUNIT_COVERAGE_PATHS" ]; then
-        BASHUNIT_COVERAGE_PATHS="src/"
-      fi
-    fi
-    bashunit::coverage::init
-  fi
-
-  local test_file
-  for test_file in "${files[@]+"${files[@]}"}"; do
-    if [ ! -f "$test_file" ]; then
-      continue
-    fi
-    unset BASHUNIT_CURRENT_TEST_ID
-    export BASHUNIT_CURRENT_SCRIPT_ID="$(bashunit::helper::generate_id "${test_file}")"
-    scripts_ids[scripts_ids_count]="${BASHUNIT_CURRENT_SCRIPT_ID}"
-    scripts_ids_count=$((scripts_ids_count + 1))
-    bashunit::internal_log "Loading file" "$test_file"
-    local source_err_file source_err source_status
-    source_err_file="$(bashunit::temp_file "source_err")"
-    # shellcheck source=/dev/null
-    source "$test_file" 2>"$source_err_file"
-    source_status=$?
-    source_err=""
-    if [ -s "$source_err_file" ]; then
-      source_err="$(cat "$source_err_file")"
-    fi
-    rm -f "$source_err_file"
-    if [ "$source_status" -ne 0 ] || [ "$(printf '%s' "$source_err" |
-      "$GREP" -cE 'syntax error|unexpected EOF' || true)" -gt 0 ]; then
-      local message="$source_err"
-      [ -z "$message" ] && message="Failed to source '$test_file' (exit $source_status)"
-      bashunit::runner::record_file_hook_failure \
-        "source" "$test_file" "$message" 1 true
-      bashunit::runner::clean_set_up_and_tear_down_after_script
-      bashunit::runner::restore_workdir
-      continue
-    fi
-    # Update function cache after sourcing new test file
-    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(declare -F | awk '{print $3}')
-    # Check if any tests match the filter before rendering header or running hooks
-    local filtered_functions
-    filtered_functions=$(bashunit::helper::get_functions_to_run "test" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
-    local functions_for_script
-    functions_for_script=$(bashunit::runner::functions_for_script "$test_file" "$filtered_functions")
-    # Apply tag filtering to the early check as well
-    if [ -n "$tag_filter" ] || [ -n "$exclude_tag_filter" ]; then
-      local _early_filtered=""
-      local _early_fn
-      for _early_fn in $functions_for_script; do
-        local _early_tags
-        _early_tags=$(bashunit::helper::get_tags_for_function "$_early_fn" "$test_file")
-        if bashunit::helper::function_matches_tags "$_early_tags" "$tag_filter" "$exclude_tag_filter"; then
-          _early_filtered="$_early_filtered $_early_fn"
-        fi
-      done
-      functions_for_script="${_early_filtered# }"
-    fi
-    if [ -z "$functions_for_script" ]; then
-      bashunit::runner::clean_set_up_and_tear_down_after_script
-      bashunit::runner::restore_workdir
-      continue
-    fi
-    # Render header BEFORE set_up_before_script so user sees activity immediately
-    bashunit::runner::render_running_file_header "$test_file"
-    # Call hook directly (not with `if !`) to preserve errexit behavior inside the hook
-    bashunit::runner::run_set_up_before_script "$test_file"
-    local setup_before_script_status=$?
-    if [ $setup_before_script_status -ne 0 ]; then
-      # Count the test functions that couldn't run due to set_up_before_script failure
-      # and add them as failed (minus 1 since the hook failure already counts as 1)
-      local filtered_functions
-      filtered_functions=$(bashunit::helper::get_functions_to_run "test" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
-      if [ -n "$filtered_functions" ]; then
-        # Bash 3.0 compatible: separate declaration and assignment for arrays
-        local functions_to_run
-        # shellcheck disable=SC2206
-        functions_to_run=($filtered_functions)
-        local additional_failures=$((${#functions_to_run[@]} - 1))
-        local i
-        for ((i = 0; i < additional_failures; i++)); do
-          bashunit::state::add_tests_failed
-        done
-      fi
-      bashunit::runner::clean_set_up_and_tear_down_after_script
-      if ! bashunit::parallel::is_enabled; then
-        bashunit::cleanup_script_temp_files
-      fi
-      bashunit::runner::restore_workdir
-      continue
-    fi
-    local _cached_fns="$functions_for_script"
-    if bashunit::parallel::is_enabled; then
-      bashunit::runner::wait_for_job_slot
-      bashunit::runner::call_test_functions \
-        "$test_file" "$filter" "$tag_filter" \
-        "$exclude_tag_filter" "$_cached_fns" 2>/dev/null &
-    else
-      bashunit::runner::call_test_functions \
-        "$test_file" "$filter" "$tag_filter" \
-        "$exclude_tag_filter" "$_cached_fns"
-    fi
-    bashunit::runner::run_tear_down_after_script "$test_file"
-    bashunit::runner::clean_set_up_and_tear_down_after_script
-    if ! bashunit::parallel::is_enabled; then
-      bashunit::cleanup_script_temp_files
-    fi
-    bashunit::internal_log "Finished file" "$test_file"
-    bashunit::runner::restore_workdir
-  done
-
-  if bashunit::parallel::is_enabled; then
-    wait
-    bashunit::runner::spinner &
-    local spinner_pid=$!
-    bashunit::parallel::aggregate_test_results "$TEMP_DIR_PARALLEL_TEST_SUITE"
-    # Kill the spinner once the aggregation finishes
-    disown "$spinner_pid" 2>/dev/null || true
-    kill "$spinner_pid" 2>/dev/null || true
-    printf "\r  \r" # Clear the spinner output
-    local script_id
-    for script_id in "${scripts_ids[@]+"${scripts_ids[@]}"}"; do
-      export BASHUNIT_CURRENT_SCRIPT_ID="${script_id}"
-      bashunit::cleanup_script_temp_files
-    done
-  fi
-}
-
-function bashunit::runner::load_bench_files() {
-  local filter=$1
-  shift
-  local IFS=$' \t\n'
-  local -a files
-  files=("$@")
-
-  local bench_file
-  for bench_file in "${files[@]+"${files[@]}"}"; do
-    [ -f "$bench_file" ] || continue
-    unset BASHUNIT_CURRENT_TEST_ID
-    export BASHUNIT_CURRENT_SCRIPT_ID="$(bashunit::helper::generate_id "${bench_file}")"
-    # shellcheck source=/dev/null
-    source "$bench_file"
-    # Update function cache after sourcing new bench file
-    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(declare -F | awk '{print $3}')
-    # Call hook directly (not with `if !`) to preserve errexit behavior inside the hook
-    bashunit::runner::run_set_up_before_script "$bench_file"
-    local setup_before_script_status=$?
-    if [ $setup_before_script_status -ne 0 ]; then
-      # Count the bench functions that couldn't run due to set_up_before_script failure
-      # and add them as failed (minus 1 since the hook failure already counts as 1)
-      local filtered_functions
-      filtered_functions=$(bashunit::helper::get_functions_to_run "bench" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
-      if [ -n "$filtered_functions" ]; then
-        # Bash 3.0 compatible: separate declaration and assignment for arrays
-        local functions_to_run
-        # shellcheck disable=SC2206
-        functions_to_run=($filtered_functions)
-        local additional_failures=$((${#functions_to_run[@]} - 1))
-        local i
-        for ((i = 0; i < additional_failures; i++)); do
-          bashunit::state::add_tests_failed
-        done
-      fi
-      bashunit::runner::clean_set_up_and_tear_down_after_script
-      bashunit::cleanup_script_temp_files
-      bashunit::runner::restore_workdir
-      continue
-    fi
-    bashunit::runner::call_bench_functions "$bench_file" "$filter"
-    bashunit::runner::run_tear_down_after_script "$bench_file"
-    bashunit::runner::clean_set_up_and_tear_down_after_script
-    bashunit::cleanup_script_temp_files
-    bashunit::runner::restore_workdir
-  done
-}
-
-function bashunit::runner::spinner() {
-  # Only show spinner when output is to a terminal
-  if [ ! -t 1 ]; then
-    # Not a terminal, just wait silently
-    while true; do sleep 1; done
-    return
-  fi
-
-  # Don't show spinner in no-progress mode
-  if bashunit::env::is_no_progress_enabled; then
-    while true; do sleep 1; done
-    return
-  fi
-
-  if bashunit::env::is_simple_output_enabled; then
-    printf "\n"
-  fi
-
-  local delay=0.1
-  local spin_chars="|/-\\"
-  while true; do
-    local i
-    for ((i = 0; i < ${#spin_chars}; i++)); do
-      printf "\r%s" "${spin_chars:$i:1}"
-      sleep "$delay"
-    done
-  done
-}
-
-function bashunit::runner::functions_for_script() {
-  local script="$1"
-  local all_fn_names="$2"
-
-  # Filter the names down to the ones defined in the script, sort them by line number
-  shopt -s extdebug
-  # shellcheck disable=SC2086
-  declare -F $all_fn_names |
-    awk -v s="$script" '$3 == s {print $1" " $2}' |
-    sort -k2 -n |
-    awk '{print $1}'
-  shopt -u extdebug
-}
-
-function bashunit::runner::parse_data_provider_args() {
-  local input="$1"
-  local current_arg=""
-  local in_quotes=false
-  local had_quotes=false # Track if arg was quoted (to preserve empty quoted strings)
-  local quote_char=""
-  local escaped=false
-  local IFS=$' \t\n'
-  local i=0
-  local arg=""
-  local encoded_arg
-  local -a args=()
-  local args_count=0
-
-  # Check for unescaped shell metacharacters that would break eval or cause
-  # globbing. Combines the leading-metachar case and the embedded-metachar
-  # case into a single regex to avoid a second grep subprocess per call.
-  local has_metachar=false
-  if [ "$(echo "$input" | "$GREP" -cE '(^|[^\])[|&;*]' || true)" -gt 0 ]; then
-    has_metachar=true
-  fi
-
-  # Try eval first (needed for $'...' from printf '%q'), unless metacharacters present
-  if [ "$has_metachar" = false ] && eval "args=($input)" 2>/dev/null; then
-    # Check if args has elements after eval
-    args_count=0
-    local _tmp arg
-    for _tmp in ${args+"${args[@]}"}; do args_count=$((args_count + 1)); done
-    if [ "$args_count" -gt 0 ]; then
-      # Successfully parsed - remove sentinel if present
-      local last_idx=$((args_count - 1))
-      if [ -z "${args[$last_idx]}" ]; then
-        unset 'args[$last_idx]'
-      fi
-      # Print args and return early
-      for arg in "${args[@]+"${args[@]}"}"; do
-        encoded_arg="$(bashunit::helper::encode_base64 "${arg}")"
-        printf '%s\n' "$encoded_arg"
-      done
-      return
-    fi
-  fi
-
-  # Fallback: parse args from the input string into an array, respecting quotes and escapes
-  local i
-  for ((i = 0; i < ${#input}; i++)); do
-    local char="${input:$i:1}"
-    if [ "$escaped" = true ]; then
-      case "$char" in
-      t) current_arg="$current_arg"$'\t' ;;
-      n) current_arg="$current_arg"$'\n' ;;
-      *) current_arg="$current_arg$char" ;;
-      esac
-      escaped=false
-    elif [ "$char" = "\\" ]; then
-      escaped=true
-    elif [ "$in_quotes" = false ]; then
-      case "$char" in
-      "$")
-        # Handle $'...' syntax
-        if [ "${input:$i:2}" = "$'" ]; then
-          in_quotes=true
-          had_quotes=true
-          quote_char="'"
-          # Skip the $
-          i=$((i + 1))
-        else
-          current_arg="$current_arg$char"
-        fi
-        ;;
-      "'" | '"')
-        in_quotes=true
-        had_quotes=true
-        quote_char="$char"
-        ;;
-      " " | $'\t')
-        # Add if non-empty OR if was quoted (to preserve empty quoted strings like '')
-        if [ -n "$current_arg" ] || [ "$had_quotes" = true ]; then
-          args[args_count]="$current_arg"
-          args_count=$((args_count + 1))
-        fi
-        current_arg=""
-        had_quotes=false
-        ;;
-      *)
-        current_arg="$current_arg$char"
-        ;;
-      esac
-    elif [ "$char" = "$quote_char" ]; then
-      in_quotes=false
-      quote_char=""
-    else
-      current_arg="$current_arg$char"
-    fi
-  done
-  args[args_count]="$current_arg"
-  args_count=$((args_count + 1))
-  # Remove all trailing empty strings
-  while [ "$args_count" -gt 0 ]; do
-    local last_idx=$((args_count - 1))
-    if [ -z "${args[$last_idx]}" ]; then
-      unset 'args[$last_idx]'
-      args_count=$((args_count - 1))
-    else
-      break
-    fi
-  done
-  # Print one arg per line to stdout, base64-encoded to preserve newlines in the data
-  local arg
-  for arg in ${args+"${args[@]}"}; do
-    encoded_arg="$(bashunit::helper::encode_base64 "${arg}")"
-    printf '%s\n' "$encoded_arg"
-  done
-}
-
-function bashunit::runner::call_test_functions() {
-  local script="$1"
-  local filter="$2"
-  local tag_filter="${3:-}"
-  local exclude_tag_filter="${4:-}"
-  local cached_functions="${5:-}"
-  local IFS=$' \t\n'
-  local -a functions_to_run=()
-  local functions_to_run_count=0
-
-  if [ -n "$cached_functions" ]; then
-    # Use pre-computed function list from load_test_files (already tag-filtered)
-    local _fn
-    for _fn in $cached_functions; do
-      [ -z "$_fn" ] && continue
-      functions_to_run[functions_to_run_count]="$_fn"
-      functions_to_run_count=$((functions_to_run_count + 1))
-    done
-  else
-    # Fallback: compute function list (for direct calls without cache)
-    local prefix="test"
-    local filtered_functions
-    filtered_functions=$(bashunit::helper::get_functions_to_run \
-      "$prefix" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
-    local _fn
-    while IFS= read -r _fn; do
-      [ -z "$_fn" ] && continue
-      functions_to_run[functions_to_run_count]="$_fn"
-      functions_to_run_count=$((functions_to_run_count + 1))
-    done < <(bashunit::runner::functions_for_script "$script" "$filtered_functions")
-
-    # Apply tag filtering if --tag or --exclude-tag was specified
-    if [ -n "$tag_filter" ] || [ -n "$exclude_tag_filter" ]; then
-      local -a tag_filtered=()
-      local tag_filtered_count=0
-      local _tf_fn
-      for _tf_fn in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
-        local fn_tags
-        fn_tags=$(bashunit::helper::get_tags_for_function "$_tf_fn" "$script")
-        if bashunit::helper::function_matches_tags "$fn_tags" "$tag_filter" "$exclude_tag_filter"; then
-          tag_filtered[tag_filtered_count]="$_tf_fn"
-          tag_filtered_count=$((tag_filtered_count + 1))
-        fi
-      done
-      functions_to_run=("${tag_filtered[@]+"${tag_filtered[@]}"}")
-      functions_to_run_count=$tag_filtered_count
-    fi
-  fi
-
-  # Randomize function order within this file. The seed is mixed with a stable
-  # per-file value (cksum of the path) so different files get different orders
-  # while staying reproducible for the resolved seed.
-  if bashunit::env::is_random_order_enabled && [ "$functions_to_run_count" -gt 1 ]; then
-    local _base _crc _fn_seed
-    _base=$(bashunit::env::seed)
-    _crc=$(printf '%s' "$script" | cksum | cut -d' ' -f1)
-    _fn_seed=$(((_base + _crc) & 2147483647))
-    local -a _shuffled_fns=()
-    local _sfn
-    while IFS= read -r _sfn; do
-      [ -n "$_sfn" ] && _shuffled_fns[${#_shuffled_fns[@]}]=$_sfn
-    done < <(printf '%s\n' "${functions_to_run[@]+"${functions_to_run[@]}"}" | bashunit::math::shuffle "$_fn_seed")
-    functions_to_run=("${_shuffled_fns[@]+"${_shuffled_fns[@]}"}")
-    functions_to_run_count=${#functions_to_run[@]}
-  fi
-
-  if [ "$functions_to_run_count" -le 0 ]; then
-    return
-  fi
-
-  bashunit::helper::check_duplicate_functions "$script" || true
-
-  # Check if test file opts out of test-level parallelism
-  local allow_test_parallel=true
-  if grep -q "^# bashunit: no-parallel-tests" "$script" 2>/dev/null; then
-    allow_test_parallel=false
-  fi
-
-  local -a provider_data=()
-  local provider_data_count=0
-  local -a parsed_data=()
-  local parsed_data_count=0
-
-  for fn_name in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
-    if bashunit::parallel::is_enabled && bashunit::parallel::must_stop_on_failure; then
-      break
-    fi
-
-    provider_data=()
-    provider_data_count=0
-    local line
-    while IFS=" " read -r line; do
-      [ -z "$line" ] && continue
-      provider_data[provider_data_count]="$line"
-      provider_data_count=$((provider_data_count + 1))
-    done <<<"$(bashunit::helper::get_provider_data "$fn_name" "$script")"
-
-    # No data provider found
-    if [ "$provider_data_count" -eq 0 ]; then
-      if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
-        bashunit::runner::wait_for_job_slot
-        bashunit::runner::run_test "$script" "$fn_name" &
-      else
-        bashunit::runner::run_test "$script" "$fn_name"
-      fi
-      unset -v fn_name
-      continue
-    fi
-
-    # Execute the test function for each line of data
-    local data
-    for data in "${provider_data[@]+"${provider_data[@]}"}"; do
-      parsed_data=()
-      parsed_data_count=0
-      local line
-      while IFS= read -r line; do
-        [ -z "$line" ] && continue
-        parsed_data[parsed_data_count]="$(bashunit::helper::decode_base64 "${line}")"
-        parsed_data_count=$((parsed_data_count + 1))
-      done <<<"$(bashunit::runner::parse_data_provider_args "$data")"
-      if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
-        bashunit::runner::wait_for_job_slot
-        bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"} &
-      else
-        bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"}
-      fi
-    done
-    unset -v fn_name
-  done
-
-  # Wait for all parallel tests within this file to complete
-  if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
-    wait
-  fi
-}
-
-function bashunit::runner::call_bench_functions() {
-  local script="$1"
-  local filter="$2"
-  local IFS=$' \t\n'
-  local prefix="bench"
-
-  # Use cached function names for better performance
-  local filtered_functions
-  filtered_functions=$(bashunit::helper::get_functions_to_run \
-    "$prefix" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
-  local -a functions_to_run=()
-  local functions_to_run_count=0
-  local _fn
-  while IFS= read -r _fn; do
-    [ -z "$_fn" ] && continue
-    functions_to_run[functions_to_run_count]="$_fn"
-    functions_to_run_count=$((functions_to_run_count + 1))
-  done < <(bashunit::runner::functions_for_script "$script" "$filtered_functions")
-
-  if [ "$functions_to_run_count" -le 0 ]; then
-    return
-  fi
-
-  if bashunit::env::is_bench_mode_enabled; then
-    bashunit::runner::render_running_file_header "$script"
-  fi
-
-  local fn_name
-  for fn_name in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
-    read -r revs its max_ms <<<"$(bashunit::benchmark::parse_annotations "$fn_name" "$script")"
-    bashunit::benchmark::run_function "$fn_name" "$revs" "$its" "$max_ms"
-    unset -v fn_name
-  done
-
-  if ! bashunit::env::is_simple_output_enabled; then
-    echo ""
-  fi
-}
-
-function bashunit::runner::render_running_file_header() {
-  local script="$1"
-  local force="${2:-false}"
-
-  bashunit::internal_log "Running file" "$script"
-
-  if [ "$force" != true ] && bashunit::parallel::is_enabled; then
-    return
-  fi
-
-  # Suppress file headers in failures-only mode
-  if bashunit::env::is_failures_only_enabled; then
-    return
-  fi
-
-  # Suppress file headers in no-progress mode
-  if bashunit::env::is_no_progress_enabled; then
-    return
-  fi
-
-  if bashunit::env::is_tap_output_enabled; then
-    printf "# %s\n" "$script"
-  elif ! bashunit::env::is_simple_output_enabled; then
-    if bashunit::env::is_verbose_enabled; then
-      printf "\n${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" "Running $script"
-    else
-      printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" "Running $script"
-    fi
-  elif bashunit::env::is_verbose_enabled; then
-    printf "\n\n${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}" "Running $script"
-  fi
-}
-
-# Result slots for the timeout-aware execution path (see run_with_timeout).
-_BASHUNIT_RUNNER_EXEC_OUT=""
-_BASHUNIT_RUNNER_TIMED_OUT="false"
-
-##
-# Runs a single test inside the capture subshell: sets up the EXIT trap that
-# encodes assertion counts/exit code, runs set_up, applies the shell mode and
-# finally invokes the test function. Meant to be called from a subshell (either
-# the `$(...)` capture or a backgrounded job), so its `set`/`trap`/`exit` calls
-# stay isolated. Emits the test stdout (with stderr merged) followed by the
-# encoded context from cleanup_on_exit.
-# Arguments: $1 test file, $2 function name, $@ test args
-##
-function bashunit::runner::execute_test_body() {
-  local test_file=$1
-  shift
-  local fn_name=$1
-  shift
-
-  # Save subshell stdout to FD 5 so the EXIT trap can restore it.
-  # When set -e kills the subshell during a redirected block in
-  # execute_test_hook, the redirect leaks into the EXIT trap,
-  # causing export_subshell_context output to be lost.
-  exec 5>&1
-  # shellcheck disable=SC2064
-  trap "exit_code=\$?; bashunit::runner::cleanup_on_exit \"$test_file\" \"\$exit_code\"" EXIT
-  bashunit::state::initialize_assertions_count
-
-  if bashunit::env::is_login_shell_enabled; then
-    bashunit::runner::source_login_shell_profiles
-  fi
-
-  # Enable coverage tracking early to include set_up/tear_down hooks
-  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
-    bashunit::coverage::enable_trap
-  fi
-
-  # Run set_up and capture exit code without || to preserve errexit behavior
-  # shellcheck disable=SC2030
-  _BASHUNIT_SETUP_COMPLETED=false
-  local setup_exit_code=0
-  bashunit::runner::run_set_up "$test_file"
-  setup_exit_code=$?
-  _BASHUNIT_SETUP_COMPLETED=true
-  if [ $setup_exit_code -ne 0 ]; then
-    exit $setup_exit_code
-  fi
-
-  # Apply shell mode setting for test execution
-  if bashunit::env::is_strict_mode_enabled; then
-    set -eu
-    # Bash 3.0 ships a broken pipefail; only enable it where it is reliable.
-    if bashunit::runner::_supports_reliable_pipefail; then
-      set -o pipefail
-    else
-      set +o pipefail
-    fi
-  else
-    set +euo pipefail
-  fi
-
-  # 2>&1: Redirects the std-error (FD 2) to the std-output (FD 1).
-  # points to the original std-output.
-  "$fn_name" "$@" 2>&1
-}
-
-##
-# Prints an encoded subshell result for a test that timed out: empty assertion
-# counters and exit code 124 (the conventional "timed out" code, already mapped
-# by classify_kill_signal). The empty TEST_HOOK_MESSAGE/TITLE/OUTPUT fields would
-# base64-encode to an empty string anyway, so the line is emitted directly rather
-# than mutating the shared _BASHUNIT_* globals (it mirrors the layout produced by
-# bashunit::state::export_subshell_context). Bash 3.0+ compatible.
-##
-function bashunit::runner::build_timeout_result() {
-  printf '%s' "##ASSERTIONS_FAILED=0##ASSERTIONS_PASSED=0##ASSERTIONS_SKIPPED=0\
-##ASSERTIONS_INCOMPLETE=0##ASSERTIONS_SNAPSHOT=0##TEST_EXIT_CODE=124\
-##TEST_HOOK_FAILURE=##TEST_HOOK_MESSAGE=##TEST_TITLE=##TEST_OUTPUT=##"
-}
-
-##
-# Runs the test body with a watchdog that kills it after BASHUNIT_TEST_TIMEOUT
-# seconds. The body runs as a backgrounded job in its own process group (set -m)
-# so the watchdog can SIGTERM/SIGKILL the whole tree — a hanging test usually
-# blocks in a child process, which signalling the subshell alone cannot reach.
-# Writes the captured result to _BASHUNIT_RUNNER_EXEC_OUT and "true"/"false" to
-# _BASHUNIT_RUNNER_TIMED_OUT. Bash 3.0+ compatible (validated on Bash 3.2).
-# Arguments: $1 test file, $2 function name, $@ test args
-##
-function bashunit::runner::run_with_timeout() {
-  local test_file=$1
-  shift
-  local fn_name=$1
-  shift
-  local secs
-  secs=$(bashunit::env::test_timeout_secs)
-
-  # NOTE: these must NOT use bashunit::temp_file — that prefixes the current
-  # test id, and cleanup_on_exit (run inside the test subshell) would unlink
-  # them via cleanup_testcase_temp_files before we read them back here.
-  local tmp_dir="${BASHUNIT_TEMP_DIR:-${TMPDIR:-/tmp}}"
-  local out_file marker_file
-  out_file="$("$MKTEMP" "$tmp_dir/bashunit_timeout_out.XXXXXXX")"
-  marker_file="$("$MKTEMP" "$tmp_dir/bashunit_timeout_marker.XXXXXXX")"
-  rm -f "$marker_file"
-
-  # Both jobs run in their own process group (set -m) so each can be killed as a
-  # whole tree. The body MUST run in an explicit ( ) subshell: a backgrounded { }
-  # group does not run its EXIT trap on normal completion, which would drop the
-  # encoded assertion context. The watchdog's fds are detached from the caller so
-  # a lingering `sleep` can never hold a captured stdout pipe open.
-  set -m
-  (bashunit::runner::execute_test_body "$test_file" "$fn_name" "$@") >"$out_file" 2>&1 &
-  local test_pid=$!
-  (
-    sleep "$secs"
-    : >"$marker_file"
-    kill -TERM -"$test_pid" 2>/dev/null
-    sleep 0.3
-    kill -KILL -"$test_pid" 2>/dev/null
-  ) </dev/null >/dev/null 2>&1 &
-  local watchdog_pid=$!
-  set +m
-
-  wait "$test_pid" 2>/dev/null
-  # Tear down the watchdog group (its `sleep` child included) so it cannot fire
-  # late or block the caller.
-  kill -TERM -"$watchdog_pid" 2>/dev/null
-  wait "$watchdog_pid" 2>/dev/null
-
-  if [ -f "$marker_file" ]; then
-    _BASHUNIT_RUNNER_TIMED_OUT="true"
-    _BASHUNIT_RUNNER_EXEC_OUT="$(bashunit::runner::build_timeout_result)"
-  else
-    _BASHUNIT_RUNNER_TIMED_OUT="false"
-    _BASHUNIT_RUNNER_EXEC_OUT="$(cat "$out_file" 2>/dev/null)"
-  fi
-
-  rm -f "$out_file" "$marker_file"
-}
-
-function bashunit::runner::run_test() {
-  local start_time
-
-  local test_file="$1"
-  shift
-  local fn_name="$1"
-  shift
-
-  bashunit::internal_log "Running test" "$fn_name" "$*"
-  bashunit::runner::export_test_identity "$test_file" "$fn_name"
-
-  bashunit::state::reset_test_title
-  bashunit::runner::apply_interpolated_title "$fn_name" "$@"
-  local interpolated_fn_name=$_BASHUNIT_RUNNER_INTERP_OUT
-  local current_assertions_failed="$_BASHUNIT_ASSERTIONS_FAILED"
-  local current_assertions_snapshot="$_BASHUNIT_ASSERTIONS_SNAPSHOT"
-  local current_assertions_incomplete="$_BASHUNIT_ASSERTIONS_INCOMPLETE"
-  local current_assertions_skipped="$_BASHUNIT_ASSERTIONS_SKIPPED"
-
-  # (FD = File Descriptor)
-  # Duplicate the current std-output (FD 1) and assigns it to FD 3.
-  # This means that FD 3 now points to wherever the std-output was pointing.
-  exec 3>&1
-
-  local test_execution_result
-  local timed_out="false"
-  local retry_max
-  retry_max=$(bashunit::env::retry_count)
-  local retries_used=0
-  # Retry wraps ONLY execution: a failed attempt is judged from its encoded
-  # result without committing, so the parse/report/counter path below still runs
-  # exactly once (on the final attempt) and nothing is double-counted. Each fork
-  # in --parallel retries itself before writing its single .result file.
-  while :; do
-    start_time=$(bashunit::clock::now)
-    if bashunit::env::is_test_timeout_enabled; then
-      bashunit::runner::run_with_timeout "$test_file" "$fn_name" "$@"
-      test_execution_result="$_BASHUNIT_RUNNER_EXEC_OUT"
-      timed_out="$_BASHUNIT_RUNNER_TIMED_OUT"
-    else
-      test_execution_result=$(bashunit::runner::execute_test_body "$test_file" "$fn_name" "$@")
-    fi
-
-    local attempt_runtime_output="${test_execution_result%%##ASSERTIONS_*}"
-    local attempt_runtime_error
-    attempt_runtime_error=$(bashunit::runner::detect_runtime_error "$attempt_runtime_output")
-    bashunit::runner::extract_result_counts "$test_execution_result"
-    # Mirror the commit-phase failure test exactly (runtime error, non-zero exit,
-    # or a failed assertion); snapshot/incomplete/skipped/risky are not failures.
-    if [ -z "$attempt_runtime_error" ] &&
-      [ "$_BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT" -eq 0 ] &&
-      [ "$_BASHUNIT_RUNNER_COUNTS_FAILED_OUT" -eq 0 ]; then
-      break
-    fi
-    [ "$retries_used" -ge "$retry_max" ] && break
-    retries_used=$((retries_used + 1))
-  done
-
-  # Closes FD 3, which was used temporarily to hold the original stdout.
-  exec 3>&-
-
-  local end_time=$(bashunit::clock::now)
-  local duration_ns=$((end_time - start_time))
-  local duration=$((duration_ns / 1000000))
-
-  if bashunit::env::is_profile_enabled; then
-    bashunit::runner::record_profile "$duration" "$interpolated_fn_name" "$test_file"
-  fi
-
-  if bashunit::env::is_verbose_enabled; then
-    bashunit::runner::print_verbose_test_summary \
-      "$test_file" "$fn_name" "$duration" "$test_execution_result"
-  fi
-
-  local subshell_output=$(bashunit::runner::decode_subshell_output "$test_execution_result")
-
-  if [ -n "$subshell_output" ]; then
-    bashunit::runner::extract_subshell_type "$subshell_output"
-    local type=$_BASHUNIT_RUNNER_TYPE_OUT
-    bashunit::runner::format_subshell_output "$subshell_output"
-    subshell_output=$_BASHUNIT_RUNNER_OUTPUT_OUT
-    if ! bashunit::env::is_failures_only_enabled; then
-      bashunit::state::print_line "$type" "$subshell_output"
-    fi
-  fi
-
-  local runtime_output="${test_execution_result%%##ASSERTIONS_*}"
-
-  local runtime_error
-  runtime_error=$(bashunit::runner::detect_runtime_error "$runtime_output")
-
-  # parse_result accumulates _BASHUNIT_TEST_EXIT_CODE; reset it so each test's
-  # exit code is read in isolation (a non-zero/timed-out test must not poison
-  # the next one).
-  _BASHUNIT_TEST_EXIT_CODE=0
-  bashunit::runner::parse_result "$fn_name" "$test_execution_result" "$@"
-
-  local test_exit_code="$_BASHUNIT_TEST_EXIT_CODE"
-
-  bashunit::runner::compute_total_assertions "$test_execution_result"
-  local total_assertions=$_BASHUNIT_RUNNER_TOTAL_OUT
-
-  bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_TITLE"
-  local encoded_test_title=$_BASHUNIT_RUNNER_FIELD_OUT
-  bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_HOOK_FAILURE"
-  local hook_failure=$_BASHUNIT_RUNNER_FIELD_OUT
-  bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_HOOK_MESSAGE"
-  local encoded_hook_message=$_BASHUNIT_RUNNER_FIELD_OUT
-
-  local test_title=""
-  [ -n "$encoded_test_title" ] && test_title="$(bashunit::helper::decode_base64 "$encoded_test_title")"
-  local hook_message=""
-  [ -n "$encoded_hook_message" ] && hook_message="$(bashunit::helper::decode_base64 "$encoded_hook_message")"
-
-  bashunit::set_test_title "$test_title"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$fn_name" "$interpolated_fn_name")"
-  bashunit::state::reset_test_title
-  bashunit::state::reset_current_test_interpolated_function_name
-
-  local failure_label="$label"
-  local failure_function="$fn_name"
-  if [ -n "$hook_failure" ]; then
-    failure_label="$(bashunit::helper::normalize_test_function_name "$hook_failure")"
-    failure_function="$hook_failure"
-  fi
-
-  if [ -n "$runtime_error" ] || [ "$test_exit_code" -ne 0 ]; then
-    bashunit::state::add_tests_failed
-    local error_message="$runtime_error"
-    if [ -n "$hook_failure" ] && [ -n "$hook_message" ]; then
-      error_message="$hook_message"
-    elif [ -z "$error_message" ] && [ -n "$hook_message" ]; then
-      error_message="$hook_message"
-    fi
-
-    # When the test was killed by a signal (or timed out), replace an empty or
-    # generic "Killed" message with a specific cause.
-    if [ -z "$hook_failure" ]; then
-      local kill_message
-      kill_message=$(bashunit::runner::classify_kill_signal "$test_exit_code")
-      if [ -n "$kill_message" ]; then
-        case "$error_message" in
-        '' | *[Kk]illed* | *[Tt]erminated*) error_message="$kill_message" ;;
-        esac
-      fi
-    fi
-
-    # A test that exceeded BASHUNIT_TEST_TIMEOUT gets a clear, specific message.
-    if [ "$timed_out" = "true" ]; then
-      error_message="Test timed out after $(bashunit::env::test_timeout_secs)s"
-    fi
-
-    bashunit::console_results::print_error_test "$failure_function" "$error_message" "$runtime_output"
-    bashunit::reports::add_test_failed "$test_file" "$failure_label" "$duration" "$total_assertions" "$error_message"
-    bashunit::runner::write_failure_result_output "$test_file" "$failure_function" "$error_message" "$runtime_output"
-    bashunit::internal_log "Test error" "$failure_label" "$error_message"
-
-    if bashunit::env::is_stop_on_failure_enabled; then
-      if bashunit::parallel::is_enabled; then
-        bashunit::parallel::mark_stop_on_failure
-      else
-        exit "$EXIT_CODE_STOP_ON_FAILURE"
-      fi
-    fi
-    return
-  fi
-
-  if [ "$current_assertions_failed" != "$_BASHUNIT_ASSERTIONS_FAILED" ]; then
-    bashunit::state::add_tests_failed
-    bashunit::reports::add_test_failed "$test_file" "$label" "$duration" "$total_assertions" "$subshell_output"
-    local assertion_runtime_output
-    assertion_runtime_output="$(
-      bashunit::runner::extract_assertion_runtime_output "$runtime_output" "$subshell_output"
-    )"
-    bashunit::runner::write_failure_result_output \
-      "$test_file" "$fn_name" "$subshell_output" "$assertion_runtime_output"
-
-    bashunit::internal_log "Test failed" "$label"
-
-    if bashunit::env::is_stop_on_failure_enabled; then
-      if bashunit::parallel::is_enabled; then
-        bashunit::parallel::mark_stop_on_failure
-      else
-        exit "$EXIT_CODE_STOP_ON_FAILURE"
-      fi
-    fi
-    return
-  fi
-
-  if [ "$current_assertions_snapshot" != "$_BASHUNIT_ASSERTIONS_SNAPSHOT" ]; then
-    bashunit::state::add_tests_snapshot
-    # In failures-only mode, suppress snapshot test output
-    if ! bashunit::env::is_failures_only_enabled; then
-      bashunit::console_results::print_snapshot_test "$label"
-    fi
-    bashunit::reports::add_test_snapshot "$test_file" "$label" "$duration" "$total_assertions"
-    bashunit::internal_log "Test snapshot" "$label"
-    return
-  fi
-
-  if [ "$current_assertions_incomplete" != "$_BASHUNIT_ASSERTIONS_INCOMPLETE" ]; then
-    bashunit::state::add_tests_incomplete
-    bashunit::reports::add_test_incomplete "$test_file" "$label" "$duration" "$total_assertions"
-    bashunit::runner::write_incomplete_result_output "$test_file" "$fn_name" "$subshell_output"
-    bashunit::internal_log "Test incomplete" "$label"
-    return
-  fi
-
-  if [ "$current_assertions_skipped" != "$_BASHUNIT_ASSERTIONS_SKIPPED" ]; then
-    bashunit::state::add_tests_skipped
-    bashunit::reports::add_test_skipped "$test_file" "$label" "$duration" "$total_assertions"
-    bashunit::runner::write_skipped_result_output "$test_file" "$fn_name" "$subshell_output"
-    bashunit::internal_log "Test skipped" "$label"
-    return
-  fi
-
-  # Check for risky test (zero assertions)
-  if [ "$total_assertions" -eq 0 ]; then
-    if bashunit::env::is_fail_on_risky_enabled; then
-      local risky_msg="Test has no assertions (risky)"
-      bashunit::state::add_tests_failed
-      bashunit::console_results::print_error_test "$fn_name" "$risky_msg"
-      bashunit::reports::add_test_failed "$test_file" "$label" "$duration" "$total_assertions" "$risky_msg"
-      bashunit::runner::write_failure_result_output "$test_file" "$fn_name" "$risky_msg"
-      bashunit::internal_log "Test failed (risky)" "$label"
-      if bashunit::env::is_stop_on_failure_enabled; then
-        if bashunit::parallel::is_enabled; then
-          bashunit::parallel::mark_stop_on_failure
-        else
-          exit "$EXIT_CODE_STOP_ON_FAILURE"
-        fi
-      fi
-      return
-    fi
-    bashunit::state::add_tests_risky
-    if ! bashunit::env::is_failures_only_enabled; then
-      bashunit::console_results::print_risky_test "${label}" "$duration"
-    fi
-    bashunit::reports::add_test_risky "$test_file" "$label" "$duration" "$total_assertions"
-    bashunit::runner::write_risky_result_output "$test_file" "$fn_name"
-    bashunit::internal_log "Test risky" "$label"
-    return
-  fi
-
-  # A test that only passed after retrying is annotated so flakiness stays visible.
-  _BASHUNIT_RETRY_NOTE=""
-  if [ "$retries_used" -gt 0 ]; then
-    _BASHUNIT_RETRY_NOTE=" (retry $retries_used/$retry_max)"
-  fi
-  # In failures-only mode, suppress successful test output
-  if ! bashunit::env::is_failures_only_enabled; then
-    if [ "$fn_name" = "$interpolated_fn_name" ]; then
-      bashunit::console_results::print_successful_test "${label}" "$duration" "$@"
-    else
-      bashunit::console_results::print_successful_test "${label}" "$duration"
-    fi
-  fi
-  _BASHUNIT_RETRY_NOTE=""
-  bashunit::state::add_tests_passed
-  bashunit::reports::add_test_passed "$test_file" "$label" "$duration" "$total_assertions"
-  bashunit::internal_log "Test passed" "$label"
-}
-
-function bashunit::runner::cleanup_on_exit() {
-  local test_file="$1"
-  local exit_code="$2"
-
-  # Disable coverage trap before cleanup to avoid interference
-  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
-    bashunit::coverage::disable_trap
-  fi
-
-  set +e
-
-  # Detect unexpected subshell exit during set_up (Issue #611).
-  # When 'source' of a non-existent file fails under set -eE, the ERR trap
-  # does not fire. On macOS Bash 3.2, $? is 0 in the EXIT trap; on Linux
-  # Bash 5.x, $? is 1. In both cases the hook failure is not recorded.
-  # Additionally, the stdout redirect from execute_test_hook leaks into the
-  # EXIT trap. Restore stdout from saved FD 5 so export_subshell_context
-  # output reaches test_execution_result.
-  # shellcheck disable=SC2031
-  if [ "${_BASHUNIT_SETUP_COMPLETED:-true}" != "true" ]; then
-    exec 1>&5
-    if [ "$exit_code" -eq 0 ]; then
-      exit_code=1
-    fi
-    if [ -z "${_BASHUNIT_TEST_HOOK_FAILURE:-}" ]; then
-      bashunit::state::set_test_hook_failure "set_up"
-      bashunit::state::set_test_hook_message "Hook 'set_up' failed unexpectedly (e.g., source of non-existent file)"
-    fi
-  fi
-
-  # Don't use || here - it disables ERR trap in the entire call chain
-  bashunit::runner::run_tear_down "$test_file"
-  local teardown_status=$?
-  bashunit::runner::clear_mocks
-  bashunit::cleanup_testcase_temp_files
-
-  if [ $teardown_status -ne 0 ]; then
-    bashunit::state::set_test_exit_code "$teardown_status"
-  else
-    bashunit::state::set_test_exit_code "$exit_code"
-  fi
-
-  bashunit::state::export_subshell_context
-}
-
-function bashunit::runner::decode_subshell_output() {
-  local test_execution_result="$1"
-
-  local test_output_base64="${test_execution_result##*##TEST_OUTPUT=}"
-  test_output_base64="${test_output_base64%%##*}"
-  bashunit::helper::decode_base64 "$test_output_base64"
-}
-
-function bashunit::runner::is_simple_progress_output() {
-  local output="$1"
-
-  [ -n "$output" ] || return 1
-
-  local color
-  for color in \
-    "$_BASHUNIT_COLOR_DEFAULT" \
-    "$_BASHUNIT_COLOR_PASSED" \
-    "$_BASHUNIT_COLOR_FAILED" \
-    "$_BASHUNIT_COLOR_SKIPPED" \
-    "$_BASHUNIT_COLOR_INCOMPLETE" \
-    "$_BASHUNIT_COLOR_SNAPSHOT" \
-    "$_BASHUNIT_COLOR_RISKY"; do
-    [ -n "$color" ] && output="${output//"$color"/}"
-  done
-
-  local i
-  local char
-  for ((i = 0; i < ${#output}; i++)); do
-    char="${output:$i:1}"
-    case "$char" in
-    "." | "F" | "S" | "I" | "N" | "R" | "E" | "?") ;;
-    *) return 1 ;;
-    esac
-  done
-
-  return 0
-}
-
-function bashunit::runner::line_exists_in_output() {
-  local needle="$1"
-  local haystack="$2"
-  local line
-
-  while IFS= read -r line || [ -n "$line" ]; do
-    [ "$line" = "$needle" ] && return 0
-  done <<<"$haystack"
-
-  return 1
-}
-
-function bashunit::runner::extract_assertion_runtime_output() {
-  local runtime_output="$1"
-  local rendered_assertion_output="$2"
-  local filtered_output=""
-  local line
-
-  while IFS= read -r line || [ -n "$line" ]; do
-    if bashunit::runner::line_exists_in_output "$line" "$rendered_assertion_output"; then
-      continue
-    fi
-    if bashunit::runner::is_simple_progress_output "$line"; then
-      continue
-    fi
-
-    [ -n "$filtered_output" ] && filtered_output="$filtered_output"$'\n'
-    filtered_output="$filtered_output$line"
-  done <<<"$runtime_output"
-
-  runtime_output="$filtered_output"
-
-  while [ -n "$runtime_output" ]; do
-    case "$runtime_output" in
-    *$'\n') runtime_output="${runtime_output%$'\n'}" ;;
-    *) break ;;
-    esac
-  done
-
-  echo "$runtime_output"
-}
-
-function bashunit::runner::parse_result() {
-  local fn_name=$1
-  shift
-  local execution_result=$1
-  shift
-  local IFS=$' \t\n'
-  local -a args
-  args=("$@")
-
-  if bashunit::parallel::is_enabled; then
-    bashunit::runner::parse_result_parallel "$fn_name" "$execution_result" ${args+"${args[@]}"}
-  else
-    bashunit::runner::parse_result_sync "$fn_name" "$execution_result"
-  fi
-}
-
-function bashunit::runner::parse_result_parallel() {
-  local fn_name=$1
-  shift
-  local execution_result=$1
-  shift
-  local IFS=$' \t\n'
-  local -a args
-  args=("$@")
-
-  local test_suite_dir="${TEMP_DIR_PARALLEL_TEST_SUITE}/$(basename "$test_file" .sh)"
-  mkdir -p "$test_suite_dir"
-
-  local sanitized_args
-  sanitized_args=$(echo "${args[*]+"${args[*]}"}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//')
-  local template
-  if [ -z "$sanitized_args" ]; then
-    template="${fn_name}.XXXXXX"
-  else
-    template="${fn_name}-${sanitized_args}.XXXXXX"
-  fi
-
-  local unique_test_result_file
-  if unique_test_result_file=$("$MKTEMP" -p "$test_suite_dir" "$template" 2>/dev/null); then
-    true
-  else
-    unique_test_result_file=$("$MKTEMP" "$test_suite_dir/$template")
-  fi
-  mv "$unique_test_result_file" "${unique_test_result_file}.result"
-  unique_test_result_file="${unique_test_result_file}.result"
-
-  bashunit::internal_log "[PARA]" "fn_name:$fn_name" "execution_result:$execution_result"
-
-  bashunit::runner::parse_result_sync "$fn_name" "$execution_result"
-
-  echo "$execution_result" >"$unique_test_result_file"
-}
-
-# shellcheck disable=SC2295
-##
-# Parses the encoded per-test result's last line into the counts out-slots
-# (_BASHUNIT_RUNNER_COUNTS_*_OUT). Pure read: never mutates the cumulative
-# _BASHUNIT_ASSERTIONS_* / _BASHUNIT_TEST_EXIT_CODE state, so the retry loop can
-# judge an attempt's outcome without committing it.
-##
-function bashunit::runner::extract_result_counts() {
-  local execution_result=$1
-
-  local result_line
-  result_line="${execution_result##*$'\n'}"
-
-  local assertions_failed=0
-  local assertions_passed=0
-  local assertions_skipped=0
-  local assertions_incomplete=0
-  local assertions_snapshot=0
-  local test_exit_code=0
-
-  # Extract values using parameter expansion instead of spawning grep/sed subprocesses
-  case "$result_line" in
-  *"ASSERTIONS_FAILED="*"##ASSERTIONS_PASSED="*)
-    local _tail
-    _tail="${result_line##*ASSERTIONS_FAILED=}"
-    assertions_failed="${_tail%%##*}"
-    _tail="${result_line##*ASSERTIONS_PASSED=}"
-    assertions_passed="${_tail%%##*}"
-    _tail="${result_line##*ASSERTIONS_SKIPPED=}"
-    assertions_skipped="${_tail%%##*}"
-    _tail="${result_line##*ASSERTIONS_INCOMPLETE=}"
-    assertions_incomplete="${_tail%%##*}"
-    _tail="${result_line##*ASSERTIONS_SNAPSHOT=}"
-    assertions_snapshot="${_tail%%##*}"
-    _tail="${result_line##*TEST_EXIT_CODE=}"
-    test_exit_code="${_tail%%##*}"
-    # Strip any trailing non-digit suffix (end of line) from the final field
-    test_exit_code="${test_exit_code%%[!0-9]*}"
-    : "${assertions_failed:=0}"
-    : "${assertions_passed:=0}"
-    : "${assertions_skipped:=0}"
-    : "${assertions_incomplete:=0}"
-    : "${assertions_snapshot:=0}"
-    : "${test_exit_code:=0}"
-    ;;
-  esac
-
-  _BASHUNIT_RUNNER_COUNTS_FAILED_OUT=$assertions_failed
-  _BASHUNIT_RUNNER_COUNTS_PASSED_OUT=$assertions_passed
-  _BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT=$assertions_skipped
-  _BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT=$assertions_incomplete
-  _BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT=$assertions_snapshot
-  _BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT=$test_exit_code
-}
-
-function bashunit::runner::parse_result_sync() {
-  local fn_name=$1
-  local execution_result=$2
-
-  bashunit::runner::extract_result_counts "$execution_result"
-
-  bashunit::internal_log "[SYNC]" "fn_name:$fn_name" "execution_result:$execution_result"
-
-  _BASHUNIT_ASSERTIONS_PASSED=$((_BASHUNIT_ASSERTIONS_PASSED + _BASHUNIT_RUNNER_COUNTS_PASSED_OUT))
-  _BASHUNIT_ASSERTIONS_FAILED=$((_BASHUNIT_ASSERTIONS_FAILED + _BASHUNIT_RUNNER_COUNTS_FAILED_OUT))
-  _BASHUNIT_ASSERTIONS_SKIPPED=$((_BASHUNIT_ASSERTIONS_SKIPPED + _BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT))
-  _BASHUNIT_ASSERTIONS_INCOMPLETE=$((_BASHUNIT_ASSERTIONS_INCOMPLETE + _BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT))
-  _BASHUNIT_ASSERTIONS_SNAPSHOT=$((_BASHUNIT_ASSERTIONS_SNAPSHOT + _BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT))
-  _BASHUNIT_TEST_EXIT_CODE=$((_BASHUNIT_TEST_EXIT_CODE + _BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT))
-
-  bashunit::internal_log "result_summary" \
-    "failed:$_BASHUNIT_RUNNER_COUNTS_FAILED_OUT" \
-    "passed:$_BASHUNIT_RUNNER_COUNTS_PASSED_OUT" \
-    "skipped:$_BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT" \
-    "incomplete:$_BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT" \
-    "snapshot:$_BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT" \
-    "exit_code:$_BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT"
-}
-
-function bashunit::runner::write_failure_result_output() {
-  local test_file=$1
-  local fn_name=$2
-  local error_msg=$3
-  local raw_output="${4:-}"
-
-  local line_number
-  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
-
-  local test_nr="*"
-  if ! bashunit::parallel::is_enabled; then
-    test_nr=$(bashunit::state::get_tests_failed)
-  fi
-
-  local output_section=""
-  if [ -n "$raw_output" ] && bashunit::env::is_show_output_on_failure_enabled; then
-    output_section="\n    Output:\n$raw_output"
-  fi
-
-  local source_context=""
-  if [ -n "$line_number" ] && [ -f "$test_file" ]; then
-    source_context=$(bashunit::runner::get_failure_source_context \
-      "$test_file" "$line_number")
-  fi
-
-  echo -e "$test_nr) $test_file:$line_number\n$error_msg$output_section$source_context" \
-    >>"$FAILURES_OUTPUT_PATH"
-}
-
-function bashunit::runner::get_failure_source_context() {
-  local file=$1
-  local fn_line=$2
-
-  local end_line start_line
-  end_line=$(wc -l <"$file")
-  start_line=$((fn_line + 1))
-
-  local line_text line_num assert_lines=""
-  line_num=$start_line
-  while [ "$line_num" -le "$end_line" ]; do
-    line_text=$(sed -n "${line_num}p" "$file")
-    # Stop at the closing brace of the function
-    if [ "$(echo "$line_text" | "$GREP" -cE '^[[:space:]]*\}[[:space:]]*$' || true)" -gt 0 ]; then
-      break
-    fi
-    # Collect lines containing assert calls
-    case "$line_text" in
-    *assert_* | *assert\ *)
-      local trimmed="${line_text#"${line_text%%[![:space:]]*}"}"
-      assert_lines="${assert_lines}\n    ${_BASHUNIT_COLOR_FAINT}${line_num}:${_BASHUNIT_COLOR_DEFAULT} ${trimmed}"
-      ;;
-    esac
-    line_num=$((line_num + 1))
-  done
-
-  if [ -n "$assert_lines" ]; then
-    echo -e "\n    ${_BASHUNIT_COLOR_FAINT}Source:${_BASHUNIT_COLOR_DEFAULT}${assert_lines}"
-  fi
-}
-
-function bashunit::runner::write_skipped_result_output() {
-  local test_file=$1
-  local fn_name=$2
-  local output_msg=$3
-
-  local line_number
-  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
-
-  local test_nr="*"
-  if ! bashunit::parallel::is_enabled; then
-    test_nr=$(bashunit::state::get_tests_skipped)
-  fi
-
-  echo -e "$test_nr) $test_file:$line_number\n$output_msg" >>"$SKIPPED_OUTPUT_PATH"
-}
-
-function bashunit::runner::write_incomplete_result_output() {
-  local test_file=$1
-  local fn_name=$2
-  local output_msg=$3
-
-  local line_number
-  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
-
-  local test_nr="*"
-  if ! bashunit::parallel::is_enabled; then
-    test_nr=$(bashunit::state::get_tests_incomplete)
-  fi
-
-  echo -e "$test_nr) $test_file:$line_number\n$output_msg" >>"$INCOMPLETE_OUTPUT_PATH"
-}
-
-function bashunit::runner::write_risky_result_output() {
-  local test_file=$1
-  local fn_name=$2
-
-  local line_number
-  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
-
-  local test_nr="*"
-  if ! bashunit::parallel::is_enabled; then
-    test_nr=$(bashunit::state::get_tests_risky)
-  fi
-
-  echo -e "$test_nr) $test_file:$line_number\nTest has no assertions (risky)" >>"$RISKY_OUTPUT_PATH"
-}
-
-function bashunit::runner::record_file_hook_failure() {
-  local hook_name="$1"
-  local test_file="$2"
-  local hook_output="$3"
-  local status="$4"
-  local render_header="${5:-false}"
-
-  if [ "$render_header" = true ]; then
-    bashunit::runner::render_running_file_header "$test_file" true
-  fi
-
-  if [ -z "$hook_output" ]; then
-    hook_output="Hook '$hook_name' failed with exit code $status"
-  fi
-
-  bashunit::state::add_tests_failed
-  bashunit::console_results::print_error_test "$hook_name" "$hook_output"
-  local _normalized_hook
-  _normalized_hook="$(bashunit::helper::normalize_test_function_name "$hook_name")"
-  bashunit::reports::add_test_failed "$test_file" "$_normalized_hook" 0 0 "$hook_output"
-  bashunit::runner::write_failure_result_output "$test_file" "$hook_name" "$hook_output"
-
-  return "$status"
-}
-
-function bashunit::runner::execute_file_hook() {
-  local hook_name="$1"
-  local test_file="$2"
-  local render_header="${3:-false}"
-
-  declare -F "$hook_name" >/dev/null 2>&1 || return 0
-
-  local hook_output=""
-  local status=0
-  local hook_output_file
-  hook_output_file=$(bashunit::temp_file "${hook_name}_output")
-
-  # Enable errtrace to catch any failing command in the hook.
-  # Using -E (errtrace) without -e (errexit) prevents the main process from
-  # exiting on source failures (Bash 3.2 doesn't trigger ERR trap with -eE).
-  # The ERR trap saves the exit status to a global variable, cleans up shell
-  # options, and returns from the hook function to prevent subsequent commands
-  # from executing.
-  # Variables set before the failure are preserved since we don't use a subshell.
-  _BASHUNIT_HOOK_ERR_STATUS=0
-  set -E
-  if bashunit::env::is_strict_mode_enabled; then
-    set -uo pipefail
-  fi
-  trap '_BASHUNIT_HOOK_ERR_STATUS=$?; set +Eu +o pipefail; trap - ERR; return $_BASHUNIT_HOOK_ERR_STATUS' ERR
-
-  {
-    "$hook_name"
-  } >"$hook_output_file" 2>&1
-
-  # Capture exit status from global variable and clean up
-  status=$_BASHUNIT_HOOK_ERR_STATUS
-  trap - ERR
-  set +Eu +o pipefail
-
-  if [ -f "$hook_output_file" ]; then
-    hook_output=""
-    local line
-    while IFS= read -r line; do
-      [ -z "$hook_output" ] && hook_output="$line" || hook_output="$hook_output"$'\n'"$line"
-    done <"$hook_output_file"
-    rm -f "$hook_output_file"
-  fi
-
-  if [ $status -ne 0 ]; then
-    bashunit::runner::record_file_hook_failure "$hook_name" "$test_file" "$hook_output" "$status" "$render_header"
-    return $status
-  fi
-
-  if [ -n "$hook_output" ] && bashunit::env::is_verbose_enabled; then
-    printf "%s\n" "$hook_output"
-  fi
-
-  return 0
-}
-
-function bashunit::runner::run_set_up() {
-  local _test_file="${1-}"
-  bashunit::internal_log "run_set_up"
-  bashunit::runner::execute_test_hook 'set_up'
-}
-
-function bashunit::runner::run_set_up_before_script() {
-  local test_file="$1"
-  bashunit::internal_log "run_set_up_before_script"
-
-  # Check if hook exists first
-  if ! declare -F "set_up_before_script" >/dev/null 2>&1; then
-    return 0
-  fi
-
-  local start_time
-  start_time=$(bashunit::clock::now)
-
-  # Enable coverage trap to attribute lines executed during set_up_before_script
-  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
-    bashunit::coverage::enable_trap
-  fi
-
-  # Execute the hook (render_header=false since header is already rendered)
-  bashunit::runner::execute_file_hook 'set_up_before_script' "$test_file" false
-  local status=$?
-
-  # Disable coverage trap after hook execution
-  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
-    bashunit::coverage::disable_trap
-  fi
-
-  local end_time
-  end_time=$(bashunit::clock::now)
-  local duration_ns=$((end_time - start_time))
-  local duration_ms=$((duration_ns / 1000000))
-
-  # Print completion message only if hook succeeded
-  if [ $status -eq 0 ]; then
-    bashunit::console_results::print_hook_completed "set_up_before_script" "$duration_ms"
-  fi
-
-  return $status
-}
-
-function bashunit::runner::run_tear_down() {
-  local _test_file="${1-}"
-  bashunit::internal_log "run_tear_down"
-  bashunit::runner::execute_test_hook 'tear_down'
-}
-
-function bashunit::runner::execute_test_hook() {
-  local hook_name="$1"
-
-  declare -F "$hook_name" >/dev/null 2>&1 || return 0
-
-  local hook_output=""
-  local status=0
-  local hook_output_file
-  hook_output_file=$(bashunit::temp_file "${hook_name}_output")
-
-  # Enable errtrace to catch any failing command in the hook.
-  # Using -E (errtrace) without -e (errexit) prevents the subshell from
-  # exiting on source failures (Bash 3.2 doesn't trigger ERR trap with -eE).
-  # The ERR trap saves the exit status to a global variable, cleans up shell
-  # options, and returns from the hook function to prevent subsequent commands
-  # from executing.
-  # Variables set before the failure are preserved since we don't use a subshell.
-  _BASHUNIT_HOOK_ERR_STATUS=0
-  set -E
-  if bashunit::env::is_strict_mode_enabled; then
-    set -uo pipefail
-  fi
-  trap '_BASHUNIT_HOOK_ERR_STATUS=$?; set +Eu +o pipefail; trap - ERR; return $_BASHUNIT_HOOK_ERR_STATUS' ERR
-
-  {
-    "$hook_name"
-  } >"$hook_output_file" 2>&1
-
-  # Capture exit status from global variable and clean up
-  status=$_BASHUNIT_HOOK_ERR_STATUS
-  trap - ERR
-  set +Eu +o pipefail
-
-  if [ -f "$hook_output_file" ]; then
-    hook_output=""
-    local line
-    while IFS= read -r line; do
-      [ -z "$hook_output" ] && hook_output="$line" || hook_output="$hook_output"$'\n'"$line"
-    done <"$hook_output_file"
-    rm -f "$hook_output_file"
-  fi
-
-  if [ $status -ne 0 ]; then
-    local message="$hook_output"
-    if [ -n "$hook_output" ]; then
-      printf "%s" "$hook_output"
-    else
-      message="Hook '$hook_name' failed with exit code $status"
-      printf "%s\n" "$message" >&2
-    fi
-    bashunit::runner::record_test_hook_failure "$hook_name" "$message" "$status"
-    return "$status"
-  fi
-
-  if [ -n "$hook_output" ]; then
-    printf "%s" "$hook_output"
-  fi
-
-  return 0
-}
-
-function bashunit::runner::record_test_hook_failure() {
-  local hook_name="$1"
-  local hook_message="$2"
-  local status="$3"
-
-  if [ -n "$_BASHUNIT_TEST_HOOK_FAILURE" ]; then
-    return "$status"
-  fi
-
-  bashunit::state::set_test_hook_failure "$hook_name"
-  bashunit::state::set_test_hook_message "$hook_message"
-
-  return "$status"
-}
-
-function bashunit::runner::clear_mocks() {
-  if [ "${#_BASHUNIT_MOCKED_FUNCTIONS[@]}" -eq 0 ]; then
-    return
-  fi
-
-  local i
-  for i in "${!_BASHUNIT_MOCKED_FUNCTIONS[@]}"; do
-    bashunit::unmock "${_BASHUNIT_MOCKED_FUNCTIONS[$i]:-}"
-  done
-}
-
-function bashunit::runner::run_tear_down_after_script() {
-  local test_file="$1"
-  bashunit::internal_log "run_tear_down_after_script"
-
-  # Check if hook exists first
-  if ! declare -F "tear_down_after_script" >/dev/null 2>&1; then
-    # Add blank line after tests if no tear_down hook
-    if ! bashunit::env::is_simple_output_enabled &&
-      ! bashunit::env::is_failures_only_enabled &&
-      ! bashunit::env::is_no_progress_enabled &&
-      ! bashunit::parallel::is_enabled; then
-      echo ""
-    fi
-    return 0
-  fi
-
-  local start_time
-  start_time=$(bashunit::clock::now)
-
-  # Enable coverage trap to attribute lines executed during tear_down_after_script
-  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
-    bashunit::coverage::enable_trap
-  fi
-
-  # Execute the hook
-  bashunit::runner::execute_file_hook 'tear_down_after_script' "$test_file"
-  local status=$?
-
-  # Disable coverage trap after hook execution
-  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
-    bashunit::coverage::disable_trap
-  fi
-
-  local end_time
-  end_time=$(bashunit::clock::now)
-  local duration_ns=$((end_time - start_time))
-  local duration_ms=$((duration_ns / 1000000))
-
-  # Print completion message only if hook succeeded
-  if [ $status -eq 0 ]; then
-    bashunit::console_results::print_hook_completed "tear_down_after_script" "$duration_ms"
-  fi
-
-  # Add blank line after tear_down output
-  if ! bashunit::env::is_simple_output_enabled &&
-    ! bashunit::env::is_failures_only_enabled &&
-    ! bashunit::env::is_no_progress_enabled &&
-    ! bashunit::parallel::is_enabled; then
-    echo ""
-  fi
-
-  return $status
-}
-
-function bashunit::runner::clean_set_up_and_tear_down_after_script() {
-  bashunit::internal_log "clean_set_up_and_tear_down_after_script"
-  bashunit::helper::unset_if_exists 'set_up'
-  bashunit::helper::unset_if_exists 'tear_down'
-  bashunit::helper::unset_if_exists 'set_up_before_script'
-  bashunit::helper::unset_if_exists 'tear_down_after_script'
-}
-
-# benchmark.sh
-
-_BASHUNIT_BENCH_NAMES=()
-_BASHUNIT_BENCH_REVS=()
-_BASHUNIT_BENCH_ITS=()
-_BASHUNIT_BENCH_AVERAGES=()
-_BASHUNIT_BENCH_MAX_MILLIS=()
-
-function bashunit::benchmark::parse_annotations() {
-  local fn_name=$1
-  local script=$2
-  local revs=1
-  local its=1
-  local max_ms=""
-
-  local annotation
-  annotation=$(awk "/function[[:space:]]+${fn_name}[[:space:]]*\(/ {print prev; exit} {prev=\$0}" "$script")
-
-  local _extracted
-  _extracted=$(echo "$annotation" | sed -n 's/.*@revs=\([0-9][0-9]*\).*/\1/p')
-  if [ -n "$_extracted" ]; then
-    revs="$_extracted"
-  else
-    _extracted=$(echo "$annotation" | sed -n 's/.*@revolutions=\([0-9][0-9]*\).*/\1/p')
-    if [ -n "$_extracted" ]; then
-      revs="$_extracted"
-    fi
-  fi
-
-  _extracted=$(echo "$annotation" | sed -n 's/.*@its=\([0-9][0-9]*\).*/\1/p')
-  if [ -n "$_extracted" ]; then
-    its="$_extracted"
-  else
-    _extracted=$(echo "$annotation" | sed -n 's/.*@iterations=\([0-9][0-9]*\).*/\1/p')
-    if [ -n "$_extracted" ]; then
-      its="$_extracted"
-    fi
-  fi
-
-  _extracted=$(echo "$annotation" | sed -n 's/.*@max_ms=\([0-9.][0-9.]*\).*/\1/p')
-  if [ -n "$_extracted" ]; then
-    max_ms="$_extracted"
-  fi
-
-  if [ -n "$max_ms" ]; then
-    echo "$revs" "$its" "$max_ms"
-  else
-    echo "$revs" "$its"
-  fi
-}
-
-function bashunit::benchmark::add_result() {
-  _BASHUNIT_BENCH_NAMES[${#_BASHUNIT_BENCH_NAMES[@]}]="$1"
-  _BASHUNIT_BENCH_REVS[${#_BASHUNIT_BENCH_REVS[@]}]="$2"
-  _BASHUNIT_BENCH_ITS[${#_BASHUNIT_BENCH_ITS[@]}]="$3"
-  _BASHUNIT_BENCH_AVERAGES[${#_BASHUNIT_BENCH_AVERAGES[@]}]="$4"
-  _BASHUNIT_BENCH_MAX_MILLIS[${#_BASHUNIT_BENCH_MAX_MILLIS[@]}]="$5"
-}
-
-# shellcheck disable=SC2155
-function bashunit::benchmark::run_function() {
-  local fn_name=$1
-  local revs=$2
-  local its=$3
-  local max_ms=$4
-  local IFS=$' \t\n'
-  local -a durations=()
-  local durations_count=0
-  local i r
-
-  for ((i = 1; i <= its; i++)); do
-    local start_time=$(bashunit::clock::now)
-    (
-      for ((r = 1; r <= revs; r++)); do
-        "$fn_name" >/dev/null 2>&1
-      done
-    )
-    local end_time=$(bashunit::clock::now)
-    local dur_ns=$(bashunit::math::calculate "($end_time - $start_time)")
-    local dur_ms=$(bashunit::math::calculate "$dur_ns / 1000000")
-    durations[durations_count]="$dur_ms"
-    durations_count=$((durations_count + 1))
-
-    if bashunit::env::is_bench_mode_enabled; then
-      local label="$(bashunit::helper::normalize_test_function_name "$fn_name")"
-      local line="$label [$i/$its] ${dur_ms} ms"
-      bashunit::state::print_line "successful" "$line"
-    fi
-  done
-
-  local sum=0
-  local d
-  for d in "${durations[@]+"${durations[@]}"}"; do
-    sum=$(bashunit::math::calculate "$sum + $d")
-  done
-  local avg=$(bashunit::math::calculate "$sum / ${#durations[@]}")
-  bashunit::benchmark::add_result "$fn_name" "$revs" "$its" "$avg" "$max_ms"
-}
-
-function bashunit::benchmark::print_results() {
-  if ! bashunit::env::is_bench_mode_enabled; then
-    return
-  fi
-
-  if ((${#_BASHUNIT_BENCH_NAMES[@]} == 0)); then
-    return
-  fi
-
-  if bashunit::env::is_simple_output_enabled; then
-    printf "\n"
-  fi
-
-  printf "\nBenchmark Results (avg ms)\n"
-  bashunit::print_line 80 "="
-  printf "\n"
-
-  local IFS=$' \t\n'
-  local has_threshold=false
-  local val
-  for val in "${_BASHUNIT_BENCH_MAX_MILLIS[@]+"${_BASHUNIT_BENCH_MAX_MILLIS[@]}"}"; do
-    if [ -n "$val" ]; then
-      has_threshold=true
-      break
-    fi
-  done
-
-  if $has_threshold; then
-    printf '%-40s %6s %6s %10s %12s\n' "Name" "Revs" "Its" "Avg(ms)" "Status"
-  else
-    printf '%-40s %6s %6s %10s\n' "Name" "Revs" "Its" "Avg(ms)"
-  fi
-
-  local i
-  for i in "${!_BASHUNIT_BENCH_NAMES[@]}"; do
-    local name="${_BASHUNIT_BENCH_NAMES[$i]:-}"
-    local revs="${_BASHUNIT_BENCH_REVS[$i]:-}"
-    local its="${_BASHUNIT_BENCH_ITS[$i]:-}"
-    local avg="${_BASHUNIT_BENCH_AVERAGES[$i]:-}"
-    local max_ms="${_BASHUNIT_BENCH_MAX_MILLIS[$i]:-}"
-
-    if [ -z "$max_ms" ]; then
-      printf '%-40s %6s %6s %10s\n' "$name" "$revs" "$its" "$avg"
-      continue
-    fi
-
-    if [ "$avg" -le "$max_ms" ]; then
-      local raw="≤ ${max_ms}"
-      local padded
-      padded=$(printf "%14s" "$raw")
-      printf '%-40s %6s %6s %10s %12s\n' "$name" "$revs" "$its" "$avg" "$padded"
-      continue
-    fi
-
-    local raw="> ${max_ms}"
-    local padded
-    padded=$(printf "%12s" "$raw")
-    printf '%-40s %6s %6s %10s %s%s%s\n' \
-      "$name" "$revs" "$its" "$avg" \
-      "$_BASHUNIT_COLOR_FAILED" "$padded" "${_BASHUNIT_COLOR_DEFAULT}"
-  done
-
-  bashunit::console_results::print_execution_time
-}
-
-# init.sh
-
-function bashunit::init::project() {
-  local tests_dir="${1:-$BASHUNIT_DEFAULT_PATH}"
-  mkdir -p "$tests_dir"
-
-  local bootstrap_file="$tests_dir/bootstrap.sh"
-  if [ ! -f "$bootstrap_file" ]; then
-    cat >"$bootstrap_file" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-# Place your common test setup here
-SH
-    chmod +x "$bootstrap_file"
-    echo "> Created $bootstrap_file"
-  fi
-
-  local example_test="$tests_dir/example_test.sh"
-  if [ ! -f "$example_test" ]; then
-    cat >"$example_test" <<'SH'
-#!/usr/bin/env bash
-
-function test_bashunit_is_installed() {
-  assert_same "bashunit is installed" "bashunit is installed"
-}
-SH
-    chmod +x "$example_test"
-    echo "> Created $example_test"
-  fi
-
-  local workflow_dir=".github/workflows"
-  local workflow_file="$workflow_dir/tests.yml"
-  if [ ! -f "$workflow_file" ]; then
-    mkdir -p "$workflow_dir"
-    cat >"$workflow_file" <<SH
-name: Tests
-on: [pull_request, push]
-jobs:
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: TypedDevs/bashunit@v0
-        with:
-          args: $tests_dir
-SH
-    echo "> Created $workflow_file"
-  fi
-
-  local env_file=".env"
-  local env_line="BASHUNIT_BOOTSTRAP=$bootstrap_file"
-  if [ -f "$env_file" ]; then
-    if grep -q "^BASHUNIT_BOOTSTRAP=" "$env_file"; then
-      if bashunit::check_os::is_macos; then
-        sed -i '' -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
-      else
-        sed -i -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
-      fi
-    fi
-    echo "$env_line" >>"$env_file"
-  else
-    echo "$env_line" >"$env_file"
-  fi
-
-  echo "> bashunit initialized in $tests_dir"
-}
-
-# learn.sh
-# shellcheck disable=SC2016
-
-##
-# Interactive learning module for bashunit
-# Provides guided tutorials and exercises to learn bashunit
-##
-
-LEARN_TEMP_DIR=""
-declare -r LEARN_PROGRESS_FILE="$HOME/.bashunit_learn_progress"
-
-##
-# Initialize learning environment
-##
-function bashunit::learn::init() {
-  LEARN_TEMP_DIR=$("${MKTEMP:-mktemp}" -d "${TMPDIR:-/tmp}/bashunit_learn.XXXXXXXX")
-  mkdir -p tests
-}
-
-##
-# Cleanup learning environment
-##
-function bashunit::learn::cleanup() {
-  if [ -n "${LEARN_TEMP_DIR:-}" ] && [ -d "$LEARN_TEMP_DIR" ]; then
-    rm -rf "$LEARN_TEMP_DIR"
-  fi
-}
-
-##
-# Print the learning menu
-##
-function bashunit::learn::print_menu() {
-  cat <<EOF
-${_BASHUNIT_COLOR_BOLD}${_BASHUNIT_COLOR_PASSED}bashunit${_BASHUNIT_COLOR_DEFAULT} - Interactive Learning
-
-Choose a lesson:
-
-  ${_BASHUNIT_COLOR_BOLD}1.${_BASHUNIT_COLOR_DEFAULT} Basics - Your First Test
-  ${_BASHUNIT_COLOR_BOLD}2.${_BASHUNIT_COLOR_DEFAULT} Assertions - Testing Different Conditions
-  ${_BASHUNIT_COLOR_BOLD}3.${_BASHUNIT_COLOR_DEFAULT} Setup & Teardown - Managing Test Lifecycle
-  ${_BASHUNIT_COLOR_BOLD}4.${_BASHUNIT_COLOR_DEFAULT} Testing Functions - Unit Testing Patterns
-  ${_BASHUNIT_COLOR_BOLD}5.${_BASHUNIT_COLOR_DEFAULT} Testing Scripts - Integration Testing
-  ${_BASHUNIT_COLOR_BOLD}6.${_BASHUNIT_COLOR_DEFAULT} Mocking - Test Doubles and Mocks
-  ${_BASHUNIT_COLOR_BOLD}7.${_BASHUNIT_COLOR_DEFAULT} Spies - Verifying Function Calls
-  ${_BASHUNIT_COLOR_BOLD}8.${_BASHUNIT_COLOR_DEFAULT} Data Providers - Parameterized Tests
-  ${_BASHUNIT_COLOR_BOLD}9.${_BASHUNIT_COLOR_DEFAULT} Exit Codes - Testing Success and Failure
-  ${_BASHUNIT_COLOR_BOLD}10.${_BASHUNIT_COLOR_DEFAULT} Complete Challenge - Real World Scenario
-
-  ${_BASHUNIT_COLOR_BOLD}p.${_BASHUNIT_COLOR_DEFAULT} Show Progress
-  ${_BASHUNIT_COLOR_BOLD}r.${_BASHUNIT_COLOR_DEFAULT} Reset Progress
-  ${_BASHUNIT_COLOR_BOLD}q.${_BASHUNIT_COLOR_DEFAULT} Quit
-
-Enter your choice:
-EOF
-}
-
-##
-# Main learning loop
-##
-function bashunit::learn::start() {
-  bashunit::learn::init
-
-  trap 'bashunit::learn::cleanup' EXIT
-
-  while true; do
-    echo ""
-    bashunit::learn::print_menu
-    read -r choice
-    echo ""
-
-    case "$choice" in
-    1) bashunit::learn::lesson_basics || true ;;
-    2) bashunit::learn::lesson_assertions || true ;;
-    3) bashunit::learn::lesson_lifecycle || true ;;
-    4) bashunit::learn::lesson_functions || true ;;
-    5) bashunit::learn::lesson_scripts || true ;;
-    6) bashunit::learn::lesson_mocking || true ;;
-    7) bashunit::learn::lesson_spies || true ;;
-    8) bashunit::learn::lesson_data_providers || true ;;
-    9) bashunit::learn::lesson_exit_codes || true ;;
-    10) bashunit::learn::lesson_challenge || true ;;
-    p) bashunit::learn::show_progress ;;
-    r) bashunit::learn::reset_progress ;;
-    q)
-      echo "${_BASHUNIT_COLOR_PASSED}Happy testing!${_BASHUNIT_COLOR_DEFAULT}"
-      break
-      ;;
-    *)
-      echo "${_BASHUNIT_COLOR_FAILED}Invalid choice. Please try again.${_BASHUNIT_COLOR_DEFAULT}"
-      ;;
-    esac
-  done
-
-  bashunit::learn::cleanup
-}
-
-##
-# Mark lesson as completed
-##
-function bashunit::learn::mark_completed() {
-  local lesson=$1
-  echo "$lesson" >>"$LEARN_PROGRESS_FILE"
-}
-
-##
-# Check if lesson is completed
-##
-function bashunit::learn::is_completed() {
-  local lesson=$1
-  [ -f "$LEARN_PROGRESS_FILE" ] && [ "$("$GREP" -c "^$lesson$" "$LEARN_PROGRESS_FILE" || true)" -gt 0 ]
-}
-
-##
-# Show learning progress
-##
-function bashunit::learn::show_progress() {
-  if [ ! -f "$LEARN_PROGRESS_FILE" ]; then
-    echo "${_BASHUNIT_COLOR_INCOMPLETE}No progress yet. Start with lesson 1!${_BASHUNIT_COLOR_DEFAULT}"
-    return
-  fi
-
-  echo "${_BASHUNIT_COLOR_BOLD}Your Progress:${_BASHUNIT_COLOR_DEFAULT}"
-  echo ""
-
-  local total_lessons=10
-  local completed=0
-
-  local i
-  for i in $(seq 1 $total_lessons); do
-    if bashunit::learn::is_completed "lesson_$i"; then
-      echo "  ${_BASHUNIT_COLOR_PASSED}✓${_BASHUNIT_COLOR_DEFAULT} Lesson $i completed"
-      ((++completed)) || true
-    else
-      echo "  ${_BASHUNIT_COLOR_INCOMPLETE}○${_BASHUNIT_COLOR_DEFAULT} Lesson $i"
-    fi
-  done
-
-  echo ""
-  echo "Progress: $completed/$total_lessons lessons completed"
-
-  if [ $completed -eq $total_lessons ]; then
-    echo ""
-    printf "%s%s🎉 Congratulations! You've completed all lessons!%s\n" \
-      "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_BOLD" "$_BASHUNIT_COLOR_DEFAULT"
-  fi
-
-  read -p "Press Enter to continue..." -r
-}
-
-##
-# Reset learning progress
-##
-function bashunit::learn::reset_progress() {
-  rm -f "$LEARN_PROGRESS_FILE"
-  echo "${_BASHUNIT_COLOR_PASSED}Progress reset successfully.${_BASHUNIT_COLOR_DEFAULT}"
-  read -p "Press Enter to continue..." -r
-}
-
-##
-# Create the example file automatically
-# Arguments: $1 - filename, $2 - file content
-##
-function bashunit::learn::create_example_file() {
-  local filename=$1
-  local content=$2
-
-  echo ""
-  echo "Creating example file ${_BASHUNIT_COLOR_BOLD}$filename${_BASHUNIT_COLOR_DEFAULT}..."
-  echo "$content" >"$filename"
-  chmod +x "$filename"
-  echo "${_BASHUNIT_COLOR_PASSED}✓ Created $filename${_BASHUNIT_COLOR_DEFAULT}"
-  echo ""
-  echo "File created! Edit it to complete the TODO items, then run this lesson again."
-  read -p "Press Enter to continue..." -r
-  return 0
-}
-
-##
-# Run a lesson test and check results
-##
-function bashunit::learn::run_lesson_test() {
-  local test_file=$1
-  local lesson_number=$2
-
-  echo "${_BASHUNIT_COLOR_BOLD}Running your test...${_BASHUNIT_COLOR_DEFAULT}"
-  echo ""
-
-  if "$BASHUNIT_ROOT_DIR/bashunit" "$test_file" --simple; then
-    echo ""
-    printf "%s%s✓ Excellent! Lesson %s completed!%s\n" \
-      "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_BOLD" "$lesson_number" "$_BASHUNIT_COLOR_DEFAULT"
-    bashunit::learn::mark_completed "lesson_$lesson_number"
-    read -p "Press Enter to continue..." -r
-    return 0
-  else
-    echo ""
-    echo "${_BASHUNIT_COLOR_FAILED}Not quite right. Review the requirements and try again.${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-}
-
-##
-# Lesson 1: Basics - Your First Test
-##
-function bashunit::learn::lesson_basics() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║                    Lesson 1: Your First Test                   ║
-╚════════════════════════════════════════════════════════════════╝
-
-Welcome to bashunit! Let's write your first test.
-
-CONCEPT: A test is a function that starts with 'test_' and uses
-assertions to verify behavior.
-
-TASK: Create a test file that checks if two values are equal.
-
-File: tests/first_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function test_bashunit_works() {
-  # TODO: Use assert_same to check if "hello" equals "hello"
-  # Hint: assert_same "expected" "actual"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • The assert_same function takes two arguments:
-    assert_same "expected" "actual"
-  • Test functions must start with "test_" prefix
-  • Always quote your strings to avoid word splitting
-  • Keep test files in a tests/ directory for better organization
-EOF
-
-  local default_file="tests/first_test.sh"
-  echo ""
-  printf "When ready, enter file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function test_bashunit_works() {
-  # TODO: Use assert_same to check if "hello" equals "hello"
-  # Hint: assert_same "expected" "actual"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  # Check if file contains assert_same
-  if [ "$("$GREP" -c "assert_same" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use assert_same${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 1
-}
-
-##
-# Lesson 2: Assertions - Testing Different Conditions
-##
-function bashunit::learn::lesson_assertions() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║              Lesson 2: Testing Different Conditions            ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: bashunit provides many assertion functions for different checks:
-  • assert_same - exact equality
-  • assert_contains - substring check
-  • assert_matches - regex pattern
-  • assert_not_same - inequality
-  • assert_empty - checks if value is empty
-  • assert_not_empty - checks if value is not empty
-
-TASK: Write a test file with 3 different assertions.
-
-File: tests/assertions_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function test_multiple_assertions() {
-  local message="Hello, bashunit!"
-
-  # TODO: Check that message contains "bashunit"
-  # Hint: assert_contains "substring" "$message"
-
-  # TODO: Check that message matches the pattern "Hello.*!"
-  # Hint: assert_matches "pattern" "$message"
-
-  # TODO: Check that message is not empty
-  # Hint: assert_not_empty "$message"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • assert_same checks exact equality (useful for strings/numbers)
-  • assert_contains is more flexible for partial matches
-  • assert_matches uses regex patterns (e.g., "^[0-9]+$" for numbers)
-  • Explore more: assert_empty, assert_true, assert_false
-EOF
-
-  local default_file="tests/assertions_test.sh"
-  echo ""
-  printf "When ready, enter file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function test_multiple_assertions() {
-  local message="Hello, bashunit!"
-
-  # TODO: Check that message contains "bashunit"
-  # Hint: assert_contains "substring" "$message"
-
-  # TODO: Check that message matches the pattern "Hello.*!"
-  # Hint: assert_matches "pattern" "$message"
-
-  # TODO: Check that message is not empty
-  # Hint: assert_not_empty "$message"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "assert_contains" "$test_file" || true)" -eq 0 ] ||
-    [ "$("$GREP" -c "assert_matches" "$test_file" || true)" -eq 0 ] ||
-    [ "$("$GREP" -c "assert_not_empty" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use all three assertion types${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 2
-}
-
-##
-# Lesson 3: Setup & Teardown - Managing Test Lifecycle
-##
-function bashunit::learn::lesson_lifecycle() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║           Lesson 3: Setup and Teardown Functions               ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Tests often need preparation and cleanup. bashunit provides:
-  • set_up() - runs before EACH test
-  • tear_down() - runs after EACH test
-  • set_up_before_script() - runs once before ALL tests
-  • tear_down_after_script() - runs once after ALL tests
-
-TASK: Create a test that uses setup and teardown to manage files.
-
-File: tests/lifecycle_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  # Create a temp file before each test
-  # TODO: export TEST_FILE="/tmp/test_$$"
-  # TODO: echo "test content" > "$TEST_FILE"
-}
-
-function tear_down() {
-  # Clean up after each test
-  # TODO: rm -f "$TEST_FILE"
-}
-
-function test_file_exists() {
-  # TODO: assert_file_exists "$TEST_FILE"
-}
-
-function test_file_has_content() {
-  # TODO: assert_file_contains "test content" "$TEST_FILE"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • set_up() runs before EACH test (good for test isolation)
-  • set_up_before_script() runs ONCE before all tests (good for expensive setup)
-  • Always clean up in tear_down() to avoid polluting other tests
-  • Use $$ for unique temp file names to avoid conflicts
-EOF
-
-  local default_file="tests/lifecycle_test.sh"
-  echo ""
-  printf "When ready, enter file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  # Create a temp file before each test
-  # TODO: export TEST_FILE="/tmp/test_$$"
-  # TODO: echo "test content" > "$TEST_FILE"
-}
-
-function tear_down() {
-  # Clean up after each test
-  # TODO: rm -f "$TEST_FILE"
-}
-
-function test_file_exists() {
-  # TODO: assert_file_exists "$TEST_FILE"
-}
-
-function test_file_has_content() {
-  # TODO: assert_file_contains "test content" "$TEST_FILE"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "function set_up()" "$test_file" || true)" -eq 0 ] ||
-    [ "$("$GREP" -c "function tear_down()" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should define set_up and tear_down functions${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 3
-}
-
-##
-# Lesson 4: Testing Functions
-##
-function bashunit::learn::lesson_functions() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║              Lesson 4: Testing Bash Functions                  ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: To test functions, source the file containing them, then
-call them in your tests.
-
-TASK: Create a script with a function, then test it.
-
-File: calculator.sh (source code)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function add() {
-  echo $(($1 + $2))
-}
-───────────────────────────────────────────────────────────────
-
-File: tests/calculator_test.sh (test file)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  # TODO: Source calculator.sh from parent directory
-  # Hint: source ../calculator.sh
-}
-
-function test_add_positive_numbers() {
-  # TODO: Test that add 2 3 returns "5"
-  # Hint: result=$(add 2 3)
-  # Hint: assert_same "5" "$result"
-}
-
-function test_add_negative_numbers() {
-  # TODO: Test that add -2 -3 returns "-5"
-  # Hint: result=$(add -2 -3)
-  # Hint: assert_same "-5" "$result"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Source files in set_up() to reload them fresh for each test
-  • Capture function output with: result=$(function_name args)
-  • Test edge cases: positive, negative, zero, large numbers
-  • Source files from parent directory: source ../file.sh
-EOF
-
-  local default_file="tests/calculator_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  # TODO: Source calculator.sh from parent directory
-  # Hint: source ../calculator.sh
-}
-
-function test_add_positive_numbers() {
-  # TODO: Test that add 2 3 returns "5"
-  # Hint: result=$(add 2 3)
-  # Hint: assert_same "5" "$result"
-}
-
-function test_add_negative_numbers() {
-  # TODO: Test that add -2 -3 returns "-5"
-  # Hint: result=$(add -2 -3)
-  # Hint: assert_same "-5" "$result"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "source" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should source the calculator.sh file${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 4
-}
-
-##
-# Lesson 5: Testing Scripts
-##
-function bashunit::learn::lesson_scripts() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║                 Lesson 5: Testing Bash Scripts                 ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Scripts that execute commands directly are tested differently.
-Run them and capture their output.
-
-TASK: Create a script and test its output.
-
-File: greeter.sh (source code)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-name=${1:-World}
-echo "Hello, $name!"
-───────────────────────────────────────────────────────────────
-
-File: tests/greeter_test.sh (test file)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function test_default_greeting() {
-  # TODO: Run greeter.sh from parent directory and capture output
-  # Hint: output=$(../greeter.sh)
-
-  # TODO: Assert output contains "Hello, World!"
-  # Hint: assert_contains "Hello, World!" "$output"
-}
-
-function test_custom_greeting() {
-  # TODO: Run greeter.sh with argument "Alice"
-  # Hint: output=$(../greeter.sh "Alice")
-
-  # TODO: Assert output contains "Hello, Alice!"
-  # Hint: assert_contains "Hello, Alice!" "$output"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Use command substitution: output=$(./script.sh)
-  • Make scripts executable: chmod +x script.sh
-  • Test both default behavior and with various arguments
-  • Scripts run in subshells, so they can't modify parent environment
-  • Run scripts from parent directory: ../script.sh
-EOF
-
-  local default_file="tests/greeter_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function test_default_greeting() {
-  # TODO: Run greeter.sh from parent directory and capture output
-  # Hint: output=$(../greeter.sh)
-
-  # TODO: Assert output contains "Hello, World!"
-  # Hint: assert_contains "Hello, World!" "$output"
-}
-
-function test_custom_greeting() {
-  # TODO: Run greeter.sh with argument "Alice"
-  # Hint: output=$(../greeter.sh "Alice")
-
-  # TODO: Assert output contains "Hello, Alice!"
-  # Hint: assert_contains "Hello, Alice!" "$output"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 5
-}
-
-##
-# Lesson 6: Mocking
-##
-function bashunit::learn::lesson_mocking() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║               Lesson 6: Mocking External Commands              ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Mocks let you override external commands or functions to
-control their behavior in tests.
-
-TASK: Test a function that uses external commands.
-
-File: system_info.sh (source code)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function get_system_info() {
-  echo "OS: $(uname -s)"
-}
-───────────────────────────────────────────────────────────────
-
-File: tests/system_info_test.sh (test file)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source ../system_info.sh
-}
-
-function test_system_info_on_linux() {
-  # TODO: Mock uname to return "Linux"
-  # Hint: mock uname echo "Linux"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Linux"
-}
-
-function test_system_info_on_macos() {
-  # TODO: Mock uname to return "Darwin"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Darwin"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Mocks replace commands/functions with custom behavior
-  • Syntax: mock command_name echo "mocked output"
-  • Mocks are automatically cleaned up after each test
-  • Use mocks to avoid calling expensive external commands
-EOF
-
-  local default_file="tests/system_info_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source ../system_info.sh
-}
-
-function test_system_info_on_linux() {
-  # TODO: Mock uname to return "Linux"
-  # Hint: mock uname echo "Linux"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Linux"
-}
-
-function test_system_info_on_macos() {
-  # TODO: Mock uname to return "Darwin"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Darwin"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "mock" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use mock${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 6
-}
-
-##
-# Lesson 7: Spies
-##
-function bashunit::learn::lesson_spies() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║              Lesson 7: Spies - Verifying Calls                 ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Spies let you verify that functions were called with specific
-arguments or a certain number of times.
-
-KEY DIFFERENCE: Spies track calls without changing behavior, while
-mocks (Lesson 6) replace the function entirely with custom behavior.
-
-TASK: Use spies to verify function calls.
-
-File: deploy.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function deploy_app() {
-  git push origin main
-  docker build -t myapp .
-  docker push myapp
-}
-───────────────────────────────────────────────────────────────
-
-File: deploy_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source deploy.sh
-}
-
-function test_deploy_calls_git_push() {
-  # TODO: Create spies for git and docker
-  # Hint: spy git
-  # Hint: spy docker
-
-  deploy_app
-
-  # TODO: Assert git was called
-  # Hint: assert_have_been_called git
-
-  # TODO: Assert docker was called
-}
-
-function test_deploy_calls_docker_twice() {
-  # TODO: Spy on docker
-
-  deploy_app
-
-  # TODO: Assert docker was called exactly 2 times
-  # Hint: assert_have_been_called_times 2 docker
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Spies track calls but don't change behavior (unlike mocks)
-  • assert_have_been_called - verifies at least one call
-  • assert_have_been_called_times N - verifies exact call count
-  • assert_have_been_called_with - verifies specific arguments
-  • Spies are cleaned up automatically after each test
-EOF
-
-  local default_file="deploy_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source deploy.sh
-}
-
-function test_deploy_calls_git_push() {
-  # TODO: Create spies for git and docker
-  # Hint: spy git
-  # Hint: spy docker
-
-  deploy_app
-
-  # TODO: Assert git was called
-  # Hint: assert_have_been_called git
-
-  # TODO: Assert docker was called
-}
-
-function test_deploy_calls_docker_twice() {
-  # TODO: Spy on docker
-
-  deploy_app
-
-  # TODO: Assert docker was called exactly 2 times
-  # Hint: assert_have_been_called_times 2 docker
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "spy" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use spy${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 7
-}
-
-##
-# Lesson 8: Data Providers
-##
-function bashunit::learn::lesson_data_providers() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║           Lesson 8: Data Providers - Parameterized Tests       ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Data providers let you run the same test with different inputs.
-Define a function that echoes test data, one per line.
-
-HOW IT WORKS: Each line from data_provider_* becomes $1 in your test.
-The test runs once for each line of data.
-
-TASK: Test multiple email formats using a data provider.
-
-File: validator.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function is_valid_email() {
-  local email_pattern='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-  [ "$(echo "$1" | "$GREP" -cE "$email_pattern" || true)" -gt 0 ]
-}
-───────────────────────────────────────────────────────────────
-
-File: validator_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source validator.sh
-}
-
-function data_provider_valid_emails() {
-  # TODO: Echo valid email addresses, one per line
-  # Example: echo "user@example.com"
-}
-
-function test_valid_emails() {
-  # $1 contains the email from data provider
-  # TODO: Assert is_valid_email succeeds
-  # Hint: assert_successful_code "is_valid_email \"$1\""
-}
-
-function data_provider_invalid_emails() {
-  # TODO: Echo invalid email addresses, one per line
-  # Example: echo "not-an-email"
-}
-
-function test_invalid_emails() {
-  # TODO: Assert is_valid_email fails
-  # Hint: assert_general_error "is_valid_email \"$1\""
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Data providers must be named: data_provider_<test_name>
-  • Each line of output becomes one test case
-  • The test function receives the line as $1
-  • Great for testing multiple inputs without duplicating code
-  • You can have multiple data provider/test pairs in one file
-EOF
-
-  local default_file="validator_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source validator.sh
-}
-
-function data_provider_valid_emails() {
-  # TODO: Echo valid email addresses, one per line
-  # Example: echo "user@example.com"
-}
-
-function test_valid_emails() {
-  # $1 contains the email from data provider
-  # TODO: Assert is_valid_email succeeds
-  # Hint: assert_successful_code "is_valid_email \"$1\""
-}
-
-function data_provider_invalid_emails() {
-  # TODO: Echo invalid email addresses, one per line
-  # Example: echo "not-an-email"
-}
-
-function test_invalid_emails() {
-  # TODO: Assert is_valid_email fails
-  # Hint: assert_general_error "is_valid_email \"$1\""
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "function data_provider_" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should define data provider functions${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 8
-}
-
-##
-# Lesson 9: Exit Codes
-##
-function bashunit::learn::lesson_exit_codes() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║             Lesson 9: Testing Exit Codes                       ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Exit codes indicate success (0) or failure (non-zero).
-bashunit provides assertions to test them:
-  • assert_successful_code - expects exit code 0
-  • assert_general_error - expects exit code 1
-  • assert_exit_code N - expects specific exit code N
-
-TASK: Test different exit codes.
-
-File: checker.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function check_file() {
-  if [ ! -e "$1" ]; then
-    echo "File not found" >&2
-    return 127
-  fi
-
-  if [ ! -r "$1" ]; then
-    echo "Permission denied" >&2
-    return 1
-  fi
-
-  echo "File OK"
-  return 0
-}
-───────────────────────────────────────────────────────────────
-
-File: checker_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source checker.sh
-  # Create a test file
-  export TEST_FILE="/tmp/test_file_$$"
-  touch "$TEST_FILE"
-}
-
-function tear_down() {
-  rm -f "$TEST_FILE"
-}
-
-function test_existing_file_returns_success() {
-  # TODO: Assert check_file succeeds with TEST_FILE
-  # Hint: assert_successful_code "check_file '$TEST_FILE'"
-}
-
-function test_missing_file_returns_127() {
-  # TODO: Assert check_file returns exit code 127 for missing file
-  # Hint: assert_exit_code 127 "check_file '/nonexistent/file'"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Exit code 0 = success (assert_successful_code)
-  • Exit code 1 = general error (assert_general_error)
-  • Other codes = specific errors (assert_exit_code N)
-  • Bash uses 'return N' in functions, 'exit N' in scripts
-  • Common codes: 127=not found, 126=not executable, 2=misuse
-EOF
-
-  local default_file="checker_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source checker.sh
-  # Create a test file
-  export TEST_FILE="/tmp/test_file_$$"
-  touch "$TEST_FILE"
-}
-
-function tear_down() {
-  rm -f "$TEST_FILE"
-}
-
-function test_existing_file_returns_success() {
-  # TODO: Assert check_file succeeds with TEST_FILE
-  # Hint: assert_successful_code "check_file '\''$TEST_FILE'\''"
-}
-
-function test_missing_file_returns_127() {
-  # TODO: Assert check_file returns exit code 127 for missing file
-  # Hint: assert_exit_code 127 "check_file '\''/nonexistent/file'\''"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  local _exit_assert_pattern="assert_successful_code\|assert_exit_code\|assert_general_error"
-  if [ "$("$GREP" -c "$_exit_assert_pattern" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use exit code assertions${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 9
-}
-
-##
-# Lesson 10: Complete Challenge
-##
-function bashunit::learn::lesson_challenge() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║          Lesson 10: Complete Challenge - Backup Script         ║
-╚════════════════════════════════════════════════════════════════╝
-
-FINAL CHALLENGE: Combine everything you've learned!
-
-CONCEPT: Real-world tests combine multiple concepts: lifecycle
-management, assertions, exit codes, and test doubles.
-
-TASK: Create a backup script and comprehensive tests.
-
-File: backup.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function create_backup() {
-  local source=$1
-  local dest=$2
-
-  if [ ! -d "$source" ]; then
-    echo "Source directory not found" >&2
-    return 1
-  fi
-
-  tar -czf "$dest" -C "$source" .
-  echo "Backup created: $dest"
-}
-───────────────────────────────────────────────────────────────
-
-File: backup_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-Your test must include:
-  1. set_up and tear_down functions
-  2. Test successful backup creation
-  3. Test failure when source doesn't exist
-  4. Mock or spy on tar command
-  5. Verify backup file exists
-  6. Check output message
-
-TIP: Combine patterns from all previous lessons!
-EOF
-
-  local default_file="backup_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source backup.sh
-  # TODO: Create test directories and variables
-}
-
-function tear_down() {
-  # TODO: Clean up test files
-}
-
-function test_successful_backup() {
-  # TODO: Test backup creation
-}
-
-function test_backup_failure_when_source_missing() {
-  # TODO: Test failure case
-}
-
-# Add more tests as needed:
-# - Mock or spy on tar command
-# - Verify backup file exists
-# - Check output message
-#
-# TIPS:
-# - Combine lifecycle (set_up/tear_down) with file assertions
-# - Use spies to verify tar was called correctly
-# - Test both success and failure scenarios
-# - Mock external commands to avoid side effects'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  # Verify the test has key components
-  local -a missing_components=()
-  local missing_components_count=0
-
-  if [ "$("$GREP" -c "function set_up()" "$test_file" || true)" -eq 0 ]; then
-    missing_components[missing_components_count]="set_up function"
-    missing_components_count=$((missing_components_count + 1))
-  fi
-
-  if [ "$("$GREP" -c "function tear_down()" "$test_file" || true)" -eq 0 ]; then
-    missing_components[missing_components_count]="tear_down function"
-    missing_components_count=$((missing_components_count + 1))
-  fi
-
-  if [ "$missing_components_count" -gt 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Missing required components:${_BASHUNIT_COLOR_DEFAULT}"
-    printf "  - %s\n" "${missing_components[@]}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  if bashunit::learn::run_lesson_test "$test_file" 10; then
-    echo ""
-    echo "${_BASHUNIT_COLOR_PASSED}${_BASHUNIT_COLOR_BOLD}"
-    cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║                   🎉 CONGRATULATIONS! 🎉                       ║
-║                                                                ║
-║          You've completed all bashunit lessons!                ║
-║                                                                ║
-║  You now know how to:                                          ║
-║    ✓ Write and run tests                                       ║
-║    ✓ Use various assertions                                    ║
-║    ✓ Manage test lifecycle                                     ║
-║    ✓ Test functions and scripts                                ║
-║    ✓ Mock external dependencies                                ║
-║    ✓ Spy on function calls                                     ║
-║    ✓ Use data providers                                        ║
-║    ✓ Test exit codes                                           ║
-║                                                                ║
-║  Next steps:                                                   ║
-║    • Explore https://bashunit.com                              ║
-║    • Check out /common-patterns for more examples              ║
-║    • Start testing your own bash scripts!                      ║
-╚════════════════════════════════════════════════════════════════╝
-EOF
-    echo "${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-  fi
 }
 
 # doc.sh
@@ -13320,60 +10196,2916 @@ function test_failure() {
 __BASHUNIT_DOCS_EOF__
 }
 
+# Single awk pass over the embedded docs: the previous line-by-line shell loop
+# forked an `echo | sed` pipe per line (~3.2k forks, ~5s for the ~1.6k-line
+# docs page); one awk fork does the same work in milliseconds (#832).
 function bashunit::doc::print_asserts() {
   local filter="${1:-}"
-  local docstring=""
-  local fn=""
-  local should_print=0
 
-  local line
-  while IFS='' read -r line || [ -n "$line" ]; do
-    fn=$(echo "$line" | sed -n 's/^## \([A-Za-z0-9_]*\).*/\1/p')
-    # Only treat assertion headings as doc entries; skip prose sections
-    # like "## Related" that are part of the documentation page but not asserts.
-    case "$fn" in
-    assert* | bashunit*) ;;
-    *) fn="" ;;
+  bashunit::doc::get_embedded_docs | awk -v filter="$filter" '
+    {
+      if ($0 ~ /^## /) {
+        # Heading word: the leading [A-Za-z0-9_]* run after "## ". Only
+        # assert*/bashunit* headings are doc entries; prose headings like
+        # "## Related" fall through and are treated as regular content.
+        fn = substr($0, 4)
+        sub(/[^A-Za-z0-9_].*$/, "", fn)
+        if (fn ~ /^(assert|bashunit)/) {
+          if (filter == "" || index(fn, filter) > 0) {
+            should_print = 1
+            print $0
+            doc = ""
+          } else {
+            should_print = 0
+          }
+          next
+        }
+      }
+
+      if (should_print) {
+        if ($0 ~ /^```/) {
+          print "--------------"
+          print doc
+          should_print = 0
+          next
+        }
+        if ($0 ~ /^::: code-group/) next
+
+        # Remove markdown link brackets and anchor tags. The bracket class
+        # uses the POSIX []][ idiom: busybox awk (Alpine) rejects
+        # backslash-escaped brackets inside a bracket expression.
+        line = $0
+        gsub(/[][]/, "", line)
+        gsub(/ *\(#[-a-z0-9]+\)/, "", line)
+        doc = doc line "\n"
+      }
+    }
+  '
+}
+
+# reports.sh
+# shellcheck disable=SC2155
+
+_BASHUNIT_REPORTS_TEST_FILES=()
+_BASHUNIT_REPORTS_TEST_NAMES=()
+_BASHUNIT_REPORTS_TEST_STATUSES=()
+_BASHUNIT_REPORTS_TEST_DURATIONS=()
+_BASHUNIT_REPORTS_TEST_ASSERTIONS=()
+_BASHUNIT_REPORTS_TEST_FAILURES=()
+_BASHUNIT_REPORTS_TEST_LINES=()
+
+function bashunit::reports::add_test_snapshot() {
+  bashunit::reports::add_test "$1" "$2" "$3" "$4" "snapshot"
+}
+
+function bashunit::reports::add_test_incomplete() {
+  bashunit::reports::add_test "$1" "$2" "$3" "$4" "incomplete"
+}
+
+function bashunit::reports::add_test_skipped() {
+  bashunit::reports::add_test "$1" "$2" "$3" "$4" "skipped"
+}
+
+function bashunit::reports::add_test_passed() {
+  bashunit::reports::add_test "$1" "$2" "$3" "$4" "passed"
+}
+
+function bashunit::reports::add_test_risky() {
+  bashunit::reports::add_test "$1" "$2" "$3" "$4" "risky"
+}
+
+function bashunit::reports::add_test_failed() {
+  bashunit::reports::add_test "$1" "$2" "$3" "$4" "failed" "$5"
+}
+
+# Returns 0 when any report output is requested.
+function bashunit::reports::is_enabled() {
+  [ -n "${BASHUNIT_LOG_JUNIT:-}" ] ||
+    [ -n "${BASHUNIT_REPORT_HTML:-}" ] ||
+    [ -n "${BASHUNIT_LOG_GHA:-}" ] ||
+    [ -n "${BASHUNIT_REPORT_TAP:-}" ] ||
+    [ -n "${BASHUNIT_REPORT_JSON:-}" ]
+}
+
+function bashunit::reports::add_test() {
+  # Skip tracking when no report output is requested
+  bashunit::reports::is_enabled || return 0
+
+  local file="$1"
+  local test_name="$2"
+  local duration="$3"
+  local assertions="$4"
+  local status="$5"
+  local failure_message="${6:-}"
+
+  # Capture the line number from the current test location ("file:line"),
+  # but only when it belongs to this test's file, so a stale location from a
+  # prior test never mislabels this entry.
+  local line=""
+  case "${_BASHUNIT_TEST_LOCATION:-}" in
+    "$file":*) line="${_BASHUNIT_TEST_LOCATION##*:}" ;;
+  esac
+
+  _BASHUNIT_REPORTS_TEST_FILES[${#_BASHUNIT_REPORTS_TEST_FILES[@]}]="$file"
+  _BASHUNIT_REPORTS_TEST_NAMES[${#_BASHUNIT_REPORTS_TEST_NAMES[@]}]="$test_name"
+  _BASHUNIT_REPORTS_TEST_STATUSES[${#_BASHUNIT_REPORTS_TEST_STATUSES[@]}]="$status"
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS[${#_BASHUNIT_REPORTS_TEST_ASSERTIONS[@]}]="$assertions"
+  _BASHUNIT_REPORTS_TEST_DURATIONS[${#_BASHUNIT_REPORTS_TEST_DURATIONS[@]}]="$duration"
+  _BASHUNIT_REPORTS_TEST_FAILURES[${#_BASHUNIT_REPORTS_TEST_FAILURES[@]}]="$failure_message"
+  _BASHUNIT_REPORTS_TEST_LINES[${#_BASHUNIT_REPORTS_TEST_LINES[@]}]="$line"
+}
+
+function bashunit::reports::__xml_escape() {
+  local text="$1"
+  # Strip ANSI escape sequences and control characters invalid in XML 1.0,
+  # then escape XML special characters (& first to avoid double-escaping)
+  echo "$text" \
+    | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
+    | tr -d '\000-\010\013\014\016-\037' \
+    | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
+}
+
+# Escapes a string for embedding in a JSON string literal (pure Bash, no jq).
+# Strips ANSI/control chars that cannot appear inline, keeps \t\r\n as escapes.
+function bashunit::reports::__json_escape() {
+  local text="$1"
+  text=$(printf '%s' "$text" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' | tr -d '\000-\010\013\014\016-\037')
+  # Backslash first so escapes added below are not doubled.
+  text="${text//\\/\\\\}"
+  text="${text//\"/\\\"}"
+  text="${text//$'\t'/\\t}"
+  text="${text//$'\r'/\\r}"
+  text="${text//$'\n'/\\n}"
+  printf '%s' "$text"
+}
+
+function bashunit::reports::generate_junit_xml() {
+  local output_file="$1"
+
+  local tests_skipped=$(bashunit::state::get_tests_skipped)
+  local tests_incomplete=$(bashunit::state::get_tests_incomplete)
+  local tests_failed=$(bashunit::state::get_tests_failed)
+  local time_ms=$(bashunit::clock::total_runtime_in_milliseconds)
+  local time
+  time=$(LC_ALL=C awk -v ms="$time_ms" 'BEGIN {printf "%.3f", ms/1000}')
+
+  {
+    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    echo "<testsuites>"
+    echo "  <testsuite name=\"bashunit\" tests=\"${#_BASHUNIT_REPORTS_TEST_NAMES[@]}\""
+    echo "             failures=\"$tests_failed\" errors=\"0\""
+    echo "             skipped=\"$(( tests_skipped + tests_incomplete ))\""
+    echo "             time=\"$time\">"
+
+    local i
+    for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+      local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
+      local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
+      local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
+      local test_time_ms="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-}"
+      local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
+      local test_time
+      test_time=$(LC_ALL=C awk -v ms="$test_time_ms" 'BEGIN {printf "%.3f", ms/1000}')
+
+      echo "    <testcase file=\"$file\""
+      echo "        name=\"$name\""
+      echo "        time=\"$test_time\">"
+
+      # Add failure element for failed tests with actual failure message
+      if [ "$status" = "failed" ]; then
+        local escaped_message
+        escaped_message=$(bashunit::reports::__xml_escape "$failure_message")
+        echo "      <failure message=\"Test failed\">$escaped_message</failure>"
+      elif [ "$status" = "risky" ]; then
+        echo "      <skipped message=\"Test has no assertions (risky)\"/>"
+      elif [ "$status" = "skipped" ]; then
+        echo "      <skipped/>"
+      elif [ "$status" = "incomplete" ]; then
+        echo "      <skipped message=\"Test incomplete\"/>"
+      fi
+
+      echo "    </testcase>"
+    done
+
+    echo "  </testsuite>"
+    echo "</testsuites>"
+  } >"$output_file"
+}
+
+##
+# Prepares a failure message for a TAP YAML diagnostic block: strips ANSI escape
+# sequences, collapses newlines to spaces and doubles single quotes so the value
+# is safe inside a YAML single-quoted scalar. Bash 3.0+ compatible.
+##
+function bashunit::reports::__tap_message() {
+  echo "$1" \
+    | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
+    | tr '\n' ' ' \
+    | sed -e "s/'/''/g"
+}
+
+##
+# Writes results in TAP version 13 format (https://testanything.org).
+# Passing/snapshot -> "ok", failed -> "not ok" with a YAML diagnostic,
+# skipped/risky -> "# SKIP", incomplete -> "# TODO".
+# Arguments: $1 - output file
+##
+function bashunit::reports::generate_report_tap() {
+  local output_file="$1"
+  local total="${#_BASHUNIT_REPORTS_TEST_NAMES[@]}"
+
+  {
+    echo "TAP version 13"
+    echo "1..$total"
+
+    local i seq=0
+    for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+      seq=$((seq + 1))
+      local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
+      local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
+      local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
+
+      case "$status" in
+      failed)
+        echo "not ok $seq - $name"
+        echo "  ---"
+        echo "  message: '$(bashunit::reports::__tap_message "$failure_message")'"
+        echo "  ..."
+        ;;
+      skipped)
+        echo "ok $seq - $name # SKIP"
+        ;;
+      risky)
+        echo "ok $seq - $name # SKIP risky (no assertions)"
+        ;;
+      incomplete)
+        echo "ok $seq - $name # TODO"
+        ;;
+      *)
+        echo "ok $seq - $name"
+        ;;
+      esac
+    done
+  } >"$output_file"
+}
+
+function bashunit::reports::generate_report_json() {
+  local output_file="$1"
+  local total="${#_BASHUNIT_REPORTS_TEST_NAMES[@]}"
+
+  local passed=0 failed=0 skipped=0 incomplete=0 duration_total=0
+  local i
+  for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+    duration_total=$((duration_total + ${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-0}))
+    case "${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}" in
+    failed) failed=$((failed + 1)) ;;
+    skipped) skipped=$((skipped + 1)) ;;
+    incomplete) incomplete=$((incomplete + 1)) ;;
+    # snapshot and risky ran without failing, so they count as passed here; the
+    # per-test "status" field below preserves the exact category.
+    *) passed=$((passed + 1)) ;;
     esac
-    if [ -n "$fn" ]; then
-      local _match=0
-      if [ -z "$filter" ]; then
-        _match=1
-      else
-        case "$fn" in *"$filter"*) _match=1 ;; esac
-      fi
-      if [ "$_match" -eq 1 ]; then
-        should_print=1
-        echo "$line"
-        docstring=""
-      else
-        should_print=0
-      fi
+  done
+
+  {
+    printf '{\n'
+    printf '  "summary": { "total": %d, "passed": %d, "failed": %d,' \
+      "$total" "$passed" "$failed"
+    printf ' "skipped": %d, "incomplete": %d, "duration_ms": %d },\n' \
+      "$skipped" "$incomplete" "$duration_total"
+    printf '  "tests": [\n'
+    local seq=0
+    for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+      local file name status duration message sep
+      file=$(bashunit::reports::__json_escape "${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}")
+      name=$(bashunit::reports::__json_escape "${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}")
+      status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
+      duration="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-0}"
+      message=$(bashunit::reports::__json_escape "${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}")
+      sep=","
+      [ "$seq" -eq "$((total - 1))" ] && sep=""
+      printf '    { "file": "%s", "name": "%s", "status": "%s", "duration_ms": %d, "message": "%s" }%s\n' \
+        "$file" "$name" "$status" "$duration" "$message" "$sep"
+      seq=$((seq + 1))
+    done
+    printf '  ]\n'
+    printf '}\n'
+  } >"$output_file"
+}
+
+function bashunit::reports::__gha_encode() {
+  local text="$1"
+  # Strip ANSI escape sequences first (one sed call)
+  text=$(printf '%s' "$text" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g')
+  # Percent-encode reserved chars per GHA workflow-commands spec.
+  # Bash 3.0+ parameter expansion avoids extra awk/sed calls.
+  # Order matters: encode '%' first so the sequences we inject stay literal.
+  text="${text//%/%25}"
+  text="${text//$'\r'/%0D}"
+  text="${text//$'\n'/%0A}"
+  printf '%s' "$text"
+}
+
+# Echoes GitHub Actions workflow-command annotations to stdout.
+# Arguments: $1 - "failed-only" to emit just errors (default: all reportable).
+function bashunit::reports::print_gha_annotations() {
+  local only="${1:-all}"
+
+  local i
+  for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+    local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
+    local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
+    local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
+    local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
+    local line="${_BASHUNIT_REPORTS_TEST_LINES[$i]:-}"
+    local level="" message=""
+
+    case "$status" in
+      failed)
+        level="error"
+        message="$failure_message"
+        ;;
+      risky)
+        level="warning"
+        message="Test has no assertions (risky)"
+        ;;
+      incomplete)
+        level="notice"
+        message="Test incomplete"
+        ;;
+      *)
+        continue
+        ;;
+    esac
+
+    if [ "$only" = "failed-only" ] && [ "$status" != "failed" ]; then
       continue
     fi
 
-    if ((should_print)); then
-      # Check for code fence using pattern matching instead of regex
-      # Avoids backtick escaping issues in Bash 3.0
-      case "$line" in
-      '```'*)
-        echo "--------------"
-        echo "$docstring"
-        should_print=0
-        continue
+    local location="file=${file}"
+    if [ -n "$line" ]; then
+      location="${location},line=${line}"
+    fi
+
+    local encoded_message
+    encoded_message=$(bashunit::reports::__gha_encode "$message")
+    echo "::${level} ${location},title=${name}::${encoded_message}"
+  done
+}
+
+function bashunit::reports::generate_gha_log() {
+  local output_file="$1"
+
+  bashunit::reports::print_gha_annotations all >"$output_file"
+}
+
+function bashunit::reports::generate_report_html() {
+  local output_file="$1"
+
+  local test_passed=$(bashunit::state::get_tests_passed)
+  local tests_skipped=$(bashunit::state::get_tests_skipped)
+  local tests_incomplete=$(bashunit::state::get_tests_incomplete)
+  local tests_snapshot=$(bashunit::state::get_tests_snapshot)
+  local tests_failed=$(bashunit::state::get_tests_failed)
+  local time=$(bashunit::clock::total_runtime_in_milliseconds)
+
+  # Temporary file to store test cases by file (use mktemp for parallel safety)
+  local temp_file
+  temp_file=$(mktemp "${TMPDIR:-/tmp}/bashunit-report.XXXXXX")
+
+  # Collect test cases by file
+  : >"$temp_file" # Clear temp file if it exists
+  local i
+  for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+    local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
+    local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
+    local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
+    local test_time="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-}"
+    local test_case="$file|$name|$status|$test_time"
+
+    echo "$test_case" >>"$temp_file"
+  done
+
+  {
+    echo "<!DOCTYPE html>"
+    echo "<html lang=\"en\">"
+    echo "<head>"
+    echo "  <meta charset=\"UTF-8\">"
+    echo "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
+    echo "  <title>Test Report</title>"
+    echo "  <style>"
+    echo "    body { font-family: Arial, sans-serif; }"
+    echo "    table { width: 100%; border-collapse: collapse; }"
+    echo "    th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }"
+    echo "    th { background-color: #f2f2f2; }"
+    echo "    .passed { background-color: #dff0d8; }"
+    echo "    .failed { background-color: #f2dede; }"
+    echo "    .skipped { background-color: #fcf8e3; }"
+    echo "    .incomplete { background-color: #d9edf7; }"
+    echo "    .snapshot { background-color: #dfe6e9; }"
+    echo "    .risky { background-color: #f5e6f5; }"
+    echo "  </style>"
+    echo "</head>"
+    echo "<body>"
+    echo "  <h1>Test Report</h1>"
+    echo "  <table>"
+    echo "    <thead>"
+    echo "      <tr>"
+    echo "        <th>Total Tests</th>"
+    echo "        <th>Passed</th>"
+    echo "        <th>Failed</th>"
+    echo "        <th>Incomplete</th>"
+    echo "        <th>Skipped</th>"
+    echo "        <th>Snapshot</th>"
+    echo "        <th>Time (ms)</th>"
+    echo "      </tr>"
+    echo "    </thead>"
+    echo "    <tbody>"
+    echo "      <tr>"
+    echo "        <td>${#_BASHUNIT_REPORTS_TEST_NAMES[@]}</td>"
+    echo "        <td>$test_passed</td>"
+    echo "        <td>$tests_failed</td>"
+    echo "        <td>$tests_incomplete</td>"
+    echo "        <td>$tests_skipped</td>"
+    echo "        <td>$tests_snapshot</td>"
+    echo "        <td>$time</td>"
+    echo "      </tr>"
+    echo "    </tbody>"
+    echo "  </table>"
+    echo "  <p>Time: $time ms</p>"
+
+    # Read the temporary file and group by file
+    local current_file=""
+    local file name status test_time
+    while IFS='|' read -r file name status test_time; do
+      if [ "$file" != "$current_file" ]; then
+        if [ -n "$current_file" ]; then
+          echo "    </tbody>"
+          echo "  </table>"
+        fi
+        echo "  <h2>File: $file</h2>"
+        echo "  <table>"
+        echo "    <thead>"
+        echo "      <tr>"
+        echo "        <th>Test Name</th>"
+        echo "        <th>Status</th>"
+        echo "        <th>Time (ms)</th>"
+        echo "      </tr>"
+        echo "    </thead>"
+        echo "    <tbody>"
+        current_file="$file"
+      fi
+      echo "      <tr class=\"$status\">"
+      echo "        <td>$name</td>"
+      echo "        <td>$status</td>"
+      echo "        <td>$test_time</td>"
+      echo "      </tr>"
+    done <"$temp_file"
+
+    # Close the last table
+    if [ -n "$current_file" ]; then
+      echo "    </tbody>"
+      echo "  </table>"
+    fi
+
+    echo "</body>"
+    echo "</html>"
+  } >"$output_file"
+
+  # Clean up temporary file
+  rm -f "$temp_file"
+}
+
+# rerun.sh
+
+##
+# --rerun-failed support.
+#
+# Recording (every run, regardless of the flag): each failing test appends its
+# raw "<test_file>:<function_name>" identity to the shared collection temp file
+# RERUN_FAILED_OUTPUT_PATH (created in env.sh). File appends work across the
+# parallel test subshells, so both modes share one collector. At the end of a
+# run the collector is persisted to the cache file (deduped); a fully green run
+# truncates it.
+#
+# Replay (only with --rerun-failed): the cache is loaded, discovery is
+# restricted to the recorded files, and each file's functions are filtered to
+# the recorded names. --filter/--tag still apply on top (intersection).
+##
+
+# Entries loaded for replay: newline-delimited "<file>:<fn>". Empty when none.
+_BASHUNIT_RERUN_ENTRIES=""
+
+##
+# Path to the persisted cache file. Defaults to ".bashunit/last-failed" under
+# the working directory; BASHUNIT_RERUN_CACHE_DIR overrides the directory.
+##
+function bashunit::rerun::cache_file() {
+  echo "${BASHUNIT_RERUN_CACHE_DIR:-.bashunit}/last-failed"
+}
+
+function bashunit::rerun::is_enabled() {
+  [ "${BASHUNIT_RERUN_FAILED:-false}" = true ]
+}
+
+##
+# Appends a failed test's raw identity to the collection temp file.
+# Arguments: $1 test file path, $2 raw function name.
+##
+function bashunit::rerun::record() {
+  local test_file=$1
+  local fn_name=$2
+  [ -n "${RERUN_FAILED_OUTPUT_PATH:-}" ] || return 0
+  printf '%s:%s\n' "$test_file" "$fn_name" >>"$RERUN_FAILED_OUTPUT_PATH" 2>/dev/null || true
+}
+
+##
+# Persists the collected failures to the cache (deduped, first-seen order).
+# A run with no collected failures truncates an existing cache. Write errors
+# (e.g. a read-only working directory) are ignored silently.
+##
+function bashunit::rerun::persist() {
+  local cache
+  cache="$(bashunit::rerun::cache_file)"
+  local collected="${RERUN_FAILED_OUTPUT_PATH:-}"
+
+  if [ -n "$collected" ] && [ -s "$collected" ]; then
+    local dir="${cache%/*}"
+    if [ "$dir" != "$cache" ]; then
+      mkdir -p "$dir" 2>/dev/null || return 0
+    fi
+    awk '!seen[$0]++' "$collected" >"$cache" 2>/dev/null || true
+  elif [ -f "$cache" ]; then
+    : >"$cache" 2>/dev/null || true
+  fi
+}
+
+##
+# Loads the cache into _BASHUNIT_RERUN_ENTRIES (empty when the cache is absent).
+##
+function bashunit::rerun::load() {
+  local cache
+  cache="$(bashunit::rerun::cache_file)"
+  _BASHUNIT_RERUN_ENTRIES=""
+  [ -f "$cache" ] || return 0
+  _BASHUNIT_RERUN_ENTRIES="$(cat "$cache" 2>/dev/null)"
+}
+
+function bashunit::rerun::has_entries() {
+  [ -n "$_BASHUNIT_RERUN_ENTRIES" ]
+}
+
+##
+# Echoes the distinct test files from the loaded entries (first-seen order).
+##
+function bashunit::rerun::files() {
+  [ -n "$_BASHUNIT_RERUN_ENTRIES" ] || return 0
+  printf '%s\n' "$_BASHUNIT_RERUN_ENTRIES" | awk '
+    NF {
+      file = $0
+      sub(/:[^:]*$/, "", file)
+      if (!seen[file]++) print file
+    }'
+}
+
+##
+# Returns 0 when "<file>:<fn>" is among the loaded entries.
+##
+function bashunit::rerun::allows() {
+  local file=$1
+  local fn=$2
+  case "
+$_BASHUNIT_RERUN_ENTRIES
+" in
+  *"
+$file:$fn
+"*) return 0 ;;
+  esac
+  return 1
+}
+
+##
+# Filters a space-separated function list down to the ones recorded for a file.
+# Arguments: $1 test file path, $2 space-separated function names.
+##
+function bashunit::rerun::filter_functions() {
+  local file=$1
+  local functions=$2
+  local kept=""
+  local fn
+  for fn in $functions; do
+    if bashunit::rerun::allows "$file" "$fn"; then
+      kept="$kept $fn"
+    fi
+  done
+  echo "${kept# }"
+}
+
+# runner.sh
+# shellcheck disable=SC2155
+
+# Pre-compiled regex pattern for parsing test result assertions
+if [ -z "${_BASHUNIT_RUNNER_PARSE_RESULT_REGEX+x}" ]; then
+  declare -r _BASHUNIT_RUNNER_PARSE_RESULT_REGEX='ASSERTIONS_FAILED=([0-9]*)##'\
+'ASSERTIONS_PASSED=([0-9]*)##ASSERTIONS_SKIPPED=([0-9]*)##'\
+'ASSERTIONS_INCOMPLETE=([0-9]*)##ASSERTIONS_SNAPSHOT=([0-9]*)##TEST_EXIT_CODE=([0-9]*)'
+fi
+
+function bashunit::runner::restore_workdir() {
+  cd "$BASHUNIT_WORKING_DIR" 2>/dev/null || true
+}
+
+##
+# Whether the running Bash has a reliable `set -o pipefail`. Bash 3.0 shipped a
+# broken pipefail (a failing pipeline can wrongly report success), which makes
+# `--strict` unsound; on 3.0 we fall back to `set -eu` without pipefail.
+# Returns: 0 when pipefail is reliable (Bash >= 3.1), 1 otherwise.
+##
+function bashunit::runner::_supports_reliable_pipefail() {
+  if [ "${BASH_VERSINFO[0]:-0}" -gt 3 ]; then
+    return 0
+  fi
+  [ "${BASH_VERSINFO[0]:-0}" -eq 3 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 1 ]
+}
+
+# Caches BASHUNIT_COVERAGE into _BASHUNIT_COVERAGE_ON ("1"|"0") so hot-path checks
+# avoid a function dispatch per call. Call once after arg parsing; tests that
+# toggle BASHUNIT_COVERAGE mid-run must call this again to refresh.
+function bashunit::runner::sync_coverage_flag() {
+  if [ "${BASHUNIT_COVERAGE-}" = "true" ]; then
+    _BASHUNIT_COVERAGE_ON=1
+  else
+    _BASHUNIT_COVERAGE_ON=0
+  fi
+}
+
+function bashunit::runner::source_login_shell_profiles() {
+  # shellcheck disable=SC1091
+  [ -f /etc/profile ] && source /etc/profile 2>/dev/null || true
+  # shellcheck disable=SC1090
+  [ -f ~/.bash_profile ] && source ~/.bash_profile 2>/dev/null || true
+  # shellcheck disable=SC1090
+  [ -f ~/.bash_login ] && source ~/.bash_login 2>/dev/null || true
+  # shellcheck disable=SC1090
+  [ -f ~/.profile ] && source ~/.profile 2>/dev/null || true
+}
+
+function bashunit::runner::export_test_identity() {
+  local test_file=$1
+  local fn_name=$2
+  bashunit::helper::generate_id "$fn_name"
+  export BASHUNIT_CURRENT_TEST_ID="$_BASHUNIT_HELPER_ID_OUT"
+  bashunit::runner::resolve_test_location "$test_file" "$fn_name"
+  export _BASHUNIT_TEST_LOCATION
+  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
+    export _BASHUNIT_COVERAGE_CURRENT_TEST_FILE="$test_file"
+    export _BASHUNIT_COVERAGE_CURRENT_TEST_FN="$fn_name"
+  fi
+}
+
+##
+# Resolves "<test_file>:<line>" for a test function and writes it into the
+# global _BASHUNIT_TEST_LOCATION, using `declare -F` under `extdebug` to read
+# the definition line. Falls back to just the file path when the line cannot be
+# determined. Bash 3.0+ compatible. Writes a global slot (no extra subshell).
+# Arguments: $1 test file, $2 function name
+##
+function bashunit::runner::resolve_test_location() {
+  local test_file=$1
+  local fn_name=$2
+
+  # Enable extdebug only inside the command-substitution subshell so it never
+  # leaks into the parent shell — globally toggling extdebug interferes with
+  # `set -e`/DEBUG-trap behavior under --strict.
+  local def line=""
+  def="$(shopt -s extdebug; declare -F "$fn_name" 2>/dev/null)" || true
+
+  # `declare -F` (with extdebug) prints "<name> <line> <file>".
+  if [ -n "$def" ]; then
+    line=${def#* }
+    line=${line%% *}
+  fi
+
+  if [ -n "$line" ]; then
+    _BASHUNIT_TEST_LOCATION="${test_file}:${line}"
+  else
+    _BASHUNIT_TEST_LOCATION="$test_file"
+  fi
+}
+
+# Writes the interpolated test-function name into _BASHUNIT_RUNNER_INTERP_OUT.
+# Arguments: $1 fn_name, $@ test arguments
+function bashunit::runner::apply_interpolated_title() {
+  local fn_name=$1
+  shift
+
+  # Only "::N::"-style names interpolate; skip the capture fork for the rest.
+  case "$fn_name" in
+  *::*) ;;
+  *)
+    bashunit::state::reset_current_test_interpolated_function_name
+    _BASHUNIT_RUNNER_INTERP_OUT=$fn_name
+    return
+    ;;
+  esac
+
+  local interpolated
+  interpolated="$(bashunit::helper::interpolate_function_name "$fn_name" "$@")"
+  if [ "$interpolated" != "$fn_name" ]; then
+    bashunit::state::set_current_test_interpolated_function_name "$interpolated"
+  else
+    bashunit::state::reset_current_test_interpolated_function_name
+  fi
+  _BASHUNIT_RUNNER_INTERP_OUT=$interpolated
+}
+
+# Hot-path result helpers below return their value via a dedicated global slot
+# (`_BASHUNIT_RUNNER_*_OUT`) instead of stdout. This avoids the per-test
+# `$(...)` subshell capture that dominated the result-parsing hot path. Callers
+# invoke the helper and immediately read the slot:
+#
+#   bashunit::runner::extract_subshell_type "$subshell_output"
+#   type=$_BASHUNIT_RUNNER_TYPE_OUT
+#
+# A dedicated slot per helper (rather than one shared slot) means nested or
+# adjacent calls cannot clobber each other and callers don't need to copy out
+# before every other helper runs.
+_BASHUNIT_RUNNER_FIELD_OUT=""
+_BASHUNIT_RUNNER_TOTAL_OUT=""
+_BASHUNIT_RUNNER_TYPE_OUT=""
+_BASHUNIT_RUNNER_OUTPUT_OUT=""
+_BASHUNIT_RUNNER_INTERP_OUT=""
+_BASHUNIT_RUNNER_COUNTS_FAILED_OUT=0
+_BASHUNIT_RUNNER_COUNTS_PASSED_OUT=0
+_BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT=0
+_BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT=0
+_BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT=0
+_BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT=0
+_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT=""
+_BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT=""
+# Suffix appended to a passed-test line when it only passed after retrying.
+_BASHUNIT_RETRY_NOTE=""
+
+# Writes the value of an encoded field (##KEY=value##) into _BASHUNIT_RUNNER_FIELD_OUT.
+# Arguments: $1 test_execution_result, $2 key
+function bashunit::runner::extract_encoded_field() {
+  local test_execution_result=$1
+  local key=$2
+  local marker="##${key}="
+  case "$test_execution_result" in
+  *"$marker"*)
+    local rest="${test_execution_result#*"$marker"}"
+    _BASHUNIT_RUNNER_FIELD_OUT="${rest%%##*}"
+    ;;
+  *) _BASHUNIT_RUNNER_FIELD_OUT="" ;;
+  esac
+}
+
+# Writes the sum of all ASSERTIONS_* counters into _BASHUNIT_RUNNER_TOTAL_OUT.
+# Arguments: $1 test_execution_result
+function bashunit::runner::compute_total_assertions() {
+  local test_execution_result=$1
+  local failed passed skipped incomplete snapshot
+  failed="${test_execution_result##*##ASSERTIONS_FAILED=}"
+  failed="${failed%%##*}"
+  passed="${test_execution_result##*##ASSERTIONS_PASSED=}"
+  passed="${passed%%##*}"
+  skipped="${test_execution_result##*##ASSERTIONS_SKIPPED=}"
+  skipped="${skipped%%##*}"
+  incomplete="${test_execution_result##*##ASSERTIONS_INCOMPLETE=}"
+  incomplete="${incomplete%%##*}"
+  snapshot="${test_execution_result##*##ASSERTIONS_SNAPSHOT=}"
+  snapshot="${snapshot%%##*}"
+  local total
+  total=$((${failed:-0} + ${passed:-0} + ${skipped:-0}))
+  total=$((total + ${incomplete:-0} + ${snapshot:-0}))
+  _BASHUNIT_RUNNER_TOTAL_OUT=$total
+}
+
+# Writes the subshell type marker (text inside leading [...]) into _BASHUNIT_RUNNER_TYPE_OUT.
+# Arguments: $1 subshell_output
+function bashunit::runner::extract_subshell_type() {
+  local subshell_output=$1
+  local type="${subshell_output%%]*}"
+  _BASHUNIT_RUNNER_TYPE_OUT="${type#[}"
+}
+
+# Writes the subshell output (minus the leading [type] marker, with embedded
+# status markers replaced by newlines) into _BASHUNIT_RUNNER_OUTPUT_OUT.
+# Arguments: $1 subshell_output
+function bashunit::runner::format_subshell_output() {
+  local subshell_output=$1
+  local line="${subshell_output#*]}"
+  line=${line//\[failed\]/$'\n'}
+  line=${line//\[skipped\]/$'\n'}
+  line=${line//\[incomplete\]/$'\n'}
+  _BASHUNIT_RUNNER_OUTPUT_OUT=$line
+}
+
+##
+# Appends a profiling record (duration, test name, file) to PROFILE_OUTPUT_PATH.
+# Uses a tab-separated, append-only line so it aggregates correctly across the
+# subshells spawned by parallel runs.
+# Arguments: $1 duration (ms), $2 test name, $3 test file
+##
+function bashunit::runner::record_profile() {
+  local duration=$1
+  local test_name=$2
+  local test_file=$3
+  printf '%s\t%s\t%s\n' "$duration" "$test_name" "$test_file" >>"$PROFILE_OUTPUT_PATH"
+}
+
+# Writes the detected runtime-error message (empty when none) into
+# _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT. Return-slot form avoids a per-test fork
+# on the hot path (#764).
+# Arguments: $1 runtime_output
+function bashunit::runner::detect_runtime_error() {
+  local runtime_output=$1
+  _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT=""
+  case "$runtime_output" in
+  *"command not found"* | *"unbound variable"* | *"permission denied"* | \
+    *"no such file or directory"* | *"syntax error"* | *"bad substitution"* | \
+    *"division by 0"* | *"cannot allocate memory"* | *"bad file descriptor"* | \
+    *"segmentation fault"* | *"illegal option"* | *"argument list too long"* | \
+    *"readonly variable"* | *"missing keyword"* | *"killed"* | \
+    *"cannot execute binary file"* | *"invalid arithmetic operator"* | \
+    *"ambiguous redirect"* | *"integer expression expected"* | \
+    *"too many arguments"* | *"value too great"* | \
+    *"not a valid identifier"* | *"unexpected EOF"*)
+    local runtime_error="${runtime_output#*: }"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="${runtime_error//$'\n'/}"
+    ;;
+  esac
+}
+
+##
+# Maps a process exit code to a human-readable description when it indicates the
+# test was killed by a signal (128 + signal) or timed out. Returns an empty
+# string for ordinary exit codes. Bash 3.0+ compatible.
+# Arguments: $1 exit code
+##
+function bashunit::runner::classify_kill_signal() {
+  local code=$1
+
+  case "$code" in
+  124) printf 'Timed out (killed by `timeout`)' ;;
+  130) printf 'Interrupted (SIGINT)' ;;
+  137) printf 'Killed (SIGKILL — out of memory or forced termination)' ;;
+  143) printf 'Terminated (SIGTERM — e.g. a timeout)' ;;
+  *)
+    # Generic "killed by signal N" for other 128+N codes (signals 1..64)
+    case "$code" in
+    '' | *[!0-9]*) return 0 ;;
+    esac
+    if [ "$code" -gt 128 ] && [ "$code" -le 192 ]; then
+      printf 'Killed by signal %s' "$((code - 128))"
+    fi
+    ;;
+  esac
+}
+
+function bashunit::runner::print_verbose_test_summary() {
+  local test_file=$1
+  local fn_name=$2
+  local duration=$3
+  local test_execution_result=$4
+
+  if bashunit::env::is_simple_output_enabled; then
+    echo ""
+  fi
+
+  printf '%*s\n' "$TERMINAL_WIDTH" '' | tr ' ' '='
+  printf "%s\n" "File:     $test_file"
+  printf "%s\n" "Function: $fn_name"
+  printf "%s\n" "Duration: $duration ms"
+  local raw_text=${test_execution_result%%##ASSERTIONS_*}
+  [ -n "$raw_text" ] && printf "%s" "Raw text: $raw_text"
+  printf "%s\n" "##ASSERTIONS_${test_execution_result#*##ASSERTIONS_}"
+  printf '%*s\n' "$TERMINAL_WIDTH" '' | tr ' ' '-'
+}
+
+# Returns 0 when this Bash supports `wait -n` (Bash 4.3+), 1 otherwise.
+function bashunit::runner::_supports_wait_n() {
+  local major="${BASH_VERSINFO[0]:-0}"
+  local minor="${BASH_VERSINFO[1]:-0}"
+  if [ "$major" -gt 4 ]; then
+    return 0
+  fi
+  if [ "$major" -eq 4 ] && [ "$minor" -ge 3 ]; then
+    return 0
+  fi
+  return 1
+}
+
+_BASHUNIT_RUNNER_RUNNING_JOBS_OUT=0
+
+# Counts running background jobs into _BASHUNIT_RUNNER_RUNNING_JOBS_OUT. `jobs -pr`
+# still needs one command substitution, but the line count is pure-bash, so this
+# drops the extra `wc` fork per poll iteration on the parallel hot path (#761).
+function bashunit::runner::_count_running_jobs() {
+  local running
+  running=$(jobs -pr)
+  if [ -z "$running" ]; then
+    _BASHUNIT_RUNNER_RUNNING_JOBS_OUT=0
+    return
+  fi
+  local newlines="${running//[!$'\n']/}"
+  _BASHUNIT_RUNNER_RUNNING_JOBS_OUT=$((${#newlines} + 1))
+}
+
+function bashunit::runner::wait_for_job_slot() {
+  local max_jobs="${BASHUNIT_PARALLEL_JOBS:-0}"
+  if [ "$max_jobs" -le 0 ]; then
+    return 0
+  fi
+
+  if bashunit::runner::_supports_wait_n; then
+    # Bash 4.3+: block until any child exits. No polling, no sleep latency.
+    bashunit::runner::_count_running_jobs
+    while [ "$_BASHUNIT_RUNNER_RUNNING_JOBS_OUT" -ge "$max_jobs" ]; do
+      wait -n 2>/dev/null || break
+      bashunit::runner::_count_running_jobs
+    done
+    return 0
+  fi
+
+  # Bash 3.x fallback: adaptive poll starting at 50ms, growing to 200ms to
+  # reduce `jobs -r` overhead on long-running tests while staying responsive.
+  local delay="0.05"
+  local iterations=0
+  while true; do
+    bashunit::runner::_count_running_jobs
+    if [ "$_BASHUNIT_RUNNER_RUNNING_JOBS_OUT" -lt "$max_jobs" ]; then
+      break
+    fi
+    sleep "$delay"
+    iterations=$((iterations + 1))
+    if [ "$iterations" -eq 4 ]; then
+      delay="0.1"
+    elif [ "$iterations" -eq 20 ]; then
+      delay="0.2"
+    fi
+  done
+}
+
+function bashunit::runner::load_test_files() {
+  local filter=$1
+  local tag_filter="${2:-}"
+  local exclude_tag_filter="${3:-}"
+  shift 3
+  local IFS=$' \t\n'
+  local -a files
+  files=("$@")
+  local -a scripts_ids=()
+  local scripts_ids_count=0
+
+  # Randomize file execution order (deterministic for the resolved seed).
+  if bashunit::env::is_random_order_enabled; then
+    local -a _shuffled_files=()
+    local _sf
+    while IFS= read -r _sf; do
+      [ -n "$_sf" ] && _shuffled_files[${#_shuffled_files[@]}]=$_sf
+    done < <(printf '%s\n' "${files[@]+"${files[@]}"}" | bashunit::math::shuffle "$(bashunit::env::seed)")
+    files=("${_shuffled_files[@]+"${_shuffled_files[@]}"}")
+  fi
+
+  bashunit::runner::sync_coverage_flag
+
+  # Initialize coverage tracking if enabled
+  if [ "$_BASHUNIT_COVERAGE_ON" = 1 ]; then
+    # Auto-discover coverage paths if not explicitly set
+    if [ -z "$BASHUNIT_COVERAGE_PATHS" ]; then
+      BASHUNIT_COVERAGE_PATHS=$(bashunit::coverage::auto_discover_paths "${files[@]}")
+      # Fallback: if auto-discovery yields no paths, track the src/ folder
+      if [ -z "$BASHUNIT_COVERAGE_PATHS" ]; then
+        BASHUNIT_COVERAGE_PATHS="src/"
+      fi
+    fi
+    bashunit::coverage::init
+  fi
+
+  local test_file
+  for test_file in "${files[@]+"${files[@]}"}"; do
+    if [ ! -f "$test_file" ]; then
+      continue
+    fi
+    unset BASHUNIT_CURRENT_TEST_ID
+    bashunit::helper::generate_id "${test_file}"
+    export BASHUNIT_CURRENT_SCRIPT_ID="$_BASHUNIT_HELPER_ID_OUT"
+    scripts_ids[scripts_ids_count]="${BASHUNIT_CURRENT_SCRIPT_ID}"
+    scripts_ids_count=$((scripts_ids_count + 1))
+    bashunit::internal_log "Loading file" "$test_file"
+    # Files are sourced sequentially in this loop (parallel workers fork after),
+    # so a fixed path in the run dir is safe: `2>` truncates it per file and the
+    # run-dir cleanup removes it, saving a mktemp and an rm fork per file.
+    local source_err_file source_err source_status
+    source_err_file="$_BASHUNIT_RUN_OUTPUT_DIR/source_err"
+    # shellcheck source=/dev/null
+    source "$test_file" 2>"$source_err_file"
+    source_status=$?
+    # A test file may enable `set -euo pipefail` at its top level; sourcing
+    # runs that in THIS shell, so a later non-zero status in the loop (e.g. a
+    # failing set_up_before_script) would kill the whole run mid-suite with no
+    # summary. Strictness is applied per-test in execute_test_body — reset the
+    # runner loop to its set +euo invariant (see main.sh exec_tests) (#836).
+    set +euo pipefail
+    source_err=""
+    if [ -s "$source_err_file" ]; then
+      source_err="$(cat "$source_err_file")"
+    fi
+    # A non-zero source status, or a syntax-error line on stderr, means the file
+    # failed to load. Match the captured stderr with `case` (no grep fork).
+    local source_failed=false
+    if [ "$source_status" -ne 0 ]; then
+      source_failed=true
+    else
+      case "$source_err" in
+      *"syntax error"* | *"unexpected EOF"*) source_failed=true ;;
+      esac
+    fi
+    if [ "$source_failed" = true ]; then
+      local message="$source_err"
+      [ -z "$message" ] && message="Failed to source '$test_file' (exit $source_status)"
+      bashunit::runner::record_file_hook_failure \
+        "source" "$test_file" "$message" 1 true
+      bashunit::runner::clean_set_up_and_tear_down_after_script
+      bashunit::runner::restore_workdir
+      continue
+    fi
+    # Update function cache after sourcing new test file (compgen is a builtin)
+    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(compgen -A function)
+    # Check if any tests match the filter before rendering header or running hooks
+    local filtered_functions
+    filtered_functions=$(bashunit::helper::get_functions_to_run "test" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
+    local functions_for_script
+    functions_for_script=$(bashunit::runner::functions_for_script "$test_file" "$filtered_functions")
+    # Full pre-tag/rerun list: these are unset once the file has been
+    # processed, whatever subset actually runs (#829).
+    local _script_fns_to_clean="$functions_for_script"
+    # Apply tag filtering to the early check as well
+    if [ -n "$tag_filter" ] || [ -n "$exclude_tag_filter" ]; then
+      bashunit::helper::build_tags_map "$test_file"
+      local _early_filtered=""
+      local _early_fn
+      for _early_fn in $functions_for_script; do
+        bashunit::helper::tags_for_function "$_early_fn"
+        if bashunit::helper::function_matches_tags "$_BASHUNIT_TAGS_OUT" "$tag_filter" "$exclude_tag_filter"; then
+          _early_filtered="$_early_filtered $_early_fn"
+        fi
+      done
+      functions_for_script="${_early_filtered# }"
+    fi
+    # Replay filtering: keep only the functions recorded as failing last run.
+    if bashunit::rerun::is_enabled && bashunit::rerun::has_entries; then
+      functions_for_script=$(bashunit::rerun::filter_functions "$test_file" "$functions_for_script")
+    fi
+    if [ -z "$functions_for_script" ]; then
+      bashunit::runner::clean_script_test_functions "$_script_fns_to_clean"
+      bashunit::runner::clean_set_up_and_tear_down_after_script
+      bashunit::runner::restore_workdir
+      continue
+    fi
+    # Render header BEFORE set_up_before_script so user sees activity immediately
+    bashunit::runner::render_running_file_header "$test_file"
+    # Call hook directly (not with `if !`) to preserve errexit behavior inside the hook
+    bashunit::runner::run_set_up_before_script "$test_file"
+    local setup_before_script_status=$?
+    if [ $setup_before_script_status -ne 0 ]; then
+      # Count the test functions that couldn't run due to set_up_before_script
+      # failure and add them as failed (minus 1 since the hook failure already
+      # counts as 1). Use this file's own function list — scanning the cached
+      # ALL-functions set would also count fns left over from earlier files
+      # and inflate the totals (#836).
+      if [ -n "$functions_for_script" ]; then
+        # Bash 3.0 compatible: separate declaration and assignment for arrays
+        local functions_to_run
+        # shellcheck disable=SC2206
+        functions_to_run=($functions_for_script)
+        local additional_failures=$((${#functions_to_run[@]} - 1))
+        local i
+        for ((i = 0; i < additional_failures; i++)); do
+          bashunit::state::add_tests_failed
+        done
+      fi
+      # Same cleanup as the success path: without it the file's test functions
+      # leak into the next iteration's counts and the main shell (#829, #836).
+      bashunit::runner::clean_script_test_functions "$_script_fns_to_clean"
+      bashunit::runner::clean_set_up_and_tear_down_after_script
+      if ! bashunit::parallel::is_enabled; then
+        bashunit::cleanup_script_temp_files
+      fi
+      bashunit::runner::restore_workdir
+      continue
+    fi
+    local _cached_fns="$functions_for_script"
+    if bashunit::parallel::is_enabled; then
+      bashunit::runner::wait_for_job_slot
+      bashunit::runner::call_test_functions \
+        "$test_file" "$filter" "$tag_filter" \
+        "$exclude_tag_filter" "$_cached_fns" 2>/dev/null &
+    else
+      bashunit::runner::call_test_functions \
+        "$test_file" "$filter" "$tag_filter" \
+        "$exclude_tag_filter" "$_cached_fns"
+    fi
+    bashunit::runner::run_tear_down_after_script "$test_file"
+    bashunit::runner::clean_script_test_functions "$_script_fns_to_clean"
+    bashunit::runner::clean_set_up_and_tear_down_after_script
+    if ! bashunit::parallel::is_enabled; then
+      bashunit::cleanup_script_temp_files
+    fi
+    bashunit::internal_log "Finished file" "$test_file"
+    bashunit::runner::restore_workdir
+  done
+
+  if bashunit::parallel::is_enabled; then
+    wait
+    bashunit::runner::spinner &
+    local spinner_pid=$!
+    bashunit::parallel::aggregate_test_results "$TEMP_DIR_PARALLEL_TEST_SUITE"
+    # Kill the spinner once the aggregation finishes
+    disown "$spinner_pid" 2>/dev/null || true
+    kill "$spinner_pid" 2>/dev/null || true
+    printf "\r  \r" # Clear the spinner output
+    local script_id
+    for script_id in "${scripts_ids[@]+"${scripts_ids[@]}"}"; do
+      export BASHUNIT_CURRENT_SCRIPT_ID="${script_id}"
+      bashunit::cleanup_script_temp_files
+    done
+  fi
+}
+
+function bashunit::runner::load_bench_files() {
+  local filter=$1
+  shift
+  local IFS=$' \t\n'
+  local -a files
+  files=("$@")
+
+  local bench_file
+  for bench_file in "${files[@]+"${files[@]}"}"; do
+    [ -f "$bench_file" ] || continue
+    unset BASHUNIT_CURRENT_TEST_ID
+    bashunit::helper::generate_id "${bench_file}"
+    export BASHUNIT_CURRENT_SCRIPT_ID="$_BASHUNIT_HELPER_ID_OUT"
+    # shellcheck source=/dev/null
+    source "$bench_file"
+    # Reset the loop's shell-mode invariant; a bench file may set -euo at top
+    # level and sourcing runs that in this shell (see the test loop) (#836).
+    set +euo pipefail
+    # Update function cache after sourcing new bench file (compgen is a builtin)
+    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(compgen -A function)
+    # Call hook directly (not with `if !`) to preserve errexit behavior inside the hook
+    bashunit::runner::run_set_up_before_script "$bench_file"
+    local setup_before_script_status=$?
+    if [ $setup_before_script_status -ne 0 ]; then
+      # Count the bench functions that couldn't run due to set_up_before_script failure
+      # and add them as failed (minus 1 since the hook failure already counts as 1)
+      local filtered_functions
+      filtered_functions=$(bashunit::helper::get_functions_to_run "bench" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
+      if [ -n "$filtered_functions" ]; then
+        # Bash 3.0 compatible: separate declaration and assignment for arrays
+        local functions_to_run
+        # shellcheck disable=SC2206
+        functions_to_run=($filtered_functions)
+        local additional_failures=$((${#functions_to_run[@]} - 1))
+        local i
+        for ((i = 0; i < additional_failures; i++)); do
+          bashunit::state::add_tests_failed
+        done
+      fi
+      bashunit::runner::clean_set_up_and_tear_down_after_script
+      bashunit::cleanup_script_temp_files
+      bashunit::runner::restore_workdir
+      continue
+    fi
+    bashunit::runner::call_bench_functions "$bench_file" "$filter"
+    bashunit::runner::run_tear_down_after_script "$bench_file"
+    bashunit::runner::clean_set_up_and_tear_down_after_script
+    bashunit::cleanup_script_temp_files
+    bashunit::runner::restore_workdir
+  done
+}
+
+function bashunit::runner::spinner() {
+  # Only show spinner when output is to a terminal
+  if [ ! -t 1 ]; then
+    # Not a terminal, just wait silently
+    while true; do sleep 1; done
+    return
+  fi
+
+  # Don't show spinner in no-progress mode
+  if bashunit::env::is_no_progress_enabled; then
+    while true; do sleep 1; done
+    return
+  fi
+
+  if bashunit::env::is_simple_output_enabled; then
+    printf "\n"
+  fi
+
+  local delay=0.1
+  local spin_chars="|/-\\"
+  while true; do
+    local i
+    for ((i = 0; i < ${#spin_chars}; i++)); do
+      printf "\r%s" "${spin_chars:$i:1}"
+      sleep "$delay"
+    done
+  done
+}
+
+function bashunit::runner::functions_for_script() {
+  local script="$1"
+  local all_fn_names="$2"
+
+  # Resolve "<name> <line> <file>" for the given names, enabling extdebug only
+  # inside the capture subshell so the caller's setting is untouched.
+  local declarations
+  # shellcheck disable=SC2086
+  declarations=$(
+    shopt -s extdebug
+    declare -F $all_fn_names 2>/dev/null
+  )
+
+  # Keep the functions defined in this script, insertion-sorted by definition
+  # line. Pure bash: the old `awk | sort | awk` pipeline cost three forks and
+  # ran twice per file, while a file's function list is small (tens of names).
+  local -a fns=()
+  local -a fn_lines=()
+  local count=0
+  local name line file i
+  while read -r name line file; do
+    [ "$file" = "$script" ] || continue
+    i=$count
+    while [ "$i" -gt 0 ] && [ "${fn_lines[i - 1]}" -gt "$line" ]; do
+      fns[i]=${fns[i - 1]}
+      fn_lines[i]=${fn_lines[i - 1]}
+      i=$((i - 1))
+    done
+    fns[i]=$name
+    fn_lines[i]=$line
+    count=$((count + 1))
+  done <<EOF
+$declarations
+EOF
+
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    echo "${fns[i]}"
+    i=$((i + 1))
+  done
+}
+
+function bashunit::runner::parse_data_provider_args() {
+  local input="$1"
+  local current_arg=""
+  local in_quotes=false
+  local had_quotes=false # Track if arg was quoted (to preserve empty quoted strings)
+  local quote_char=""
+  local escaped=false
+  local IFS=$' \t\n'
+  local i=0
+  local arg=""
+  local encoded_arg
+  local -a args=()
+  local args_count=0
+
+  # Check for unescaped shell metacharacters that would break eval or cause
+  # globbing. Combines the leading-metachar case and the embedded-metachar
+  # case into a single regex to avoid a second grep subprocess per call.
+  local has_metachar=false
+  if [ "$(echo "$input" | "$GREP" -cE '(^|[^\])[|&;*]' || true)" -gt 0 ]; then
+    has_metachar=true
+  fi
+
+  # Try eval first (needed for $'...' from printf '%q'), unless metacharacters present
+  if [ "$has_metachar" = false ] && eval "args=($input)" 2>/dev/null; then
+    # Check if args has elements after eval
+    args_count=0
+    local _tmp arg
+    for _tmp in ${args+"${args[@]}"}; do args_count=$((args_count + 1)); done
+    if [ "$args_count" -gt 0 ]; then
+      # Successfully parsed - remove sentinel if present
+      local last_idx=$((args_count - 1))
+      if [ -z "${args[$last_idx]}" ]; then
+        unset 'args[$last_idx]'
+      fi
+      # Print args and return early
+      for arg in "${args[@]+"${args[@]}"}"; do
+        encoded_arg="$(bashunit::helper::encode_base64 "${arg}")"
+        printf '%s\n' "$encoded_arg"
+      done
+      return
+    fi
+  fi
+
+  # Fallback: parse args from the input string into an array, respecting quotes and escapes
+  local i
+  for ((i = 0; i < ${#input}; i++)); do
+    local char="${input:$i:1}"
+    if [ "$escaped" = true ]; then
+      case "$char" in
+      t) current_arg="$current_arg"$'\t' ;;
+      n) current_arg="$current_arg"$'\n' ;;
+      *) current_arg="$current_arg$char" ;;
+      esac
+      escaped=false
+    elif [ "$char" = "\\" ]; then
+      escaped=true
+    elif [ "$in_quotes" = false ]; then
+      case "$char" in
+      "$")
+        # Handle $'...' syntax
+        if [ "${input:$i:2}" = "$'" ]; then
+          in_quotes=true
+          had_quotes=true
+          quote_char="'"
+          # Skip the $
+          i=$((i + 1))
+        else
+          current_arg="$current_arg$char"
+        fi
+        ;;
+      "'" | '"')
+        in_quotes=true
+        had_quotes=true
+        quote_char="$char"
+        ;;
+      " " | $'\t')
+        # Add if non-empty OR if was quoted (to preserve empty quoted strings like '')
+        if [ -n "$current_arg" ] || [ "$had_quotes" = true ]; then
+          args[args_count]="$current_arg"
+          args_count=$((args_count + 1))
+        fi
+        current_arg=""
+        had_quotes=false
+        ;;
+      *)
+        current_arg="$current_arg$char"
         ;;
       esac
-
-      case "$line" in
-      "::: code-group"*) continue ;;
-      esac
-
-      # Remove markdown link brackets and anchor tags
-      line="${line//[\[\]]/}"
-      line="$(sed -E 's/ *\(#[-a-z0-9]+\)//g' <<<"$line")"
-      docstring="$docstring$line"$'\n'
+    elif [ "$char" = "$quote_char" ]; then
+      in_quotes=false
+      quote_char=""
+    else
+      current_arg="$current_arg$char"
     fi
-  done <<<"$(bashunit::doc::get_embedded_docs)"
+  done
+  args[args_count]="$current_arg"
+  args_count=$((args_count + 1))
+  # Remove all trailing empty strings
+  while [ "$args_count" -gt 0 ]; do
+    local last_idx=$((args_count - 1))
+    if [ -z "${args[$last_idx]}" ]; then
+      unset 'args[$last_idx]'
+      args_count=$((args_count - 1))
+    else
+      break
+    fi
+  done
+  # Print one arg per line to stdout, base64-encoded to preserve newlines in the data
+  local arg
+  for arg in ${args+"${args[@]}"}; do
+    encoded_arg="$(bashunit::helper::encode_base64 "${arg}")"
+    printf '%s\n' "$encoded_arg"
+  done
+}
+
+function bashunit::runner::call_test_functions() {
+  local script="$1"
+  local filter="$2"
+  local tag_filter="${3:-}"
+  local exclude_tag_filter="${4:-}"
+  local cached_functions="${5:-}"
+  local IFS=$' \t\n'
+  local -a functions_to_run=()
+  local functions_to_run_count=0
+
+  if [ -n "$cached_functions" ]; then
+    # Use pre-computed function list from load_test_files (already tag-filtered)
+    local _fn
+    for _fn in $cached_functions; do
+      [ -z "$_fn" ] && continue
+      functions_to_run[functions_to_run_count]="$_fn"
+      functions_to_run_count=$((functions_to_run_count + 1))
+    done
+  else
+    # Fallback: compute function list (for direct calls without cache)
+    local prefix="test"
+    local filtered_functions
+    filtered_functions=$(bashunit::helper::get_functions_to_run \
+      "$prefix" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
+    local _fn
+    while IFS= read -r _fn; do
+      [ -z "$_fn" ] && continue
+      functions_to_run[functions_to_run_count]="$_fn"
+      functions_to_run_count=$((functions_to_run_count + 1))
+    done < <(bashunit::runner::functions_for_script "$script" "$filtered_functions")
+
+    # Apply tag filtering if --tag or --exclude-tag was specified
+    if [ -n "$tag_filter" ] || [ -n "$exclude_tag_filter" ]; then
+      bashunit::helper::build_tags_map "$script"
+      local -a tag_filtered=()
+      local tag_filtered_count=0
+      local _tf_fn
+      for _tf_fn in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
+        bashunit::helper::tags_for_function "$_tf_fn"
+        if bashunit::helper::function_matches_tags "$_BASHUNIT_TAGS_OUT" "$tag_filter" "$exclude_tag_filter"; then
+          tag_filtered[tag_filtered_count]="$_tf_fn"
+          tag_filtered_count=$((tag_filtered_count + 1))
+        fi
+      done
+      functions_to_run=("${tag_filtered[@]+"${tag_filtered[@]}"}")
+      functions_to_run_count=$tag_filtered_count
+    fi
+  fi
+
+  # Randomize function order within this file. The seed is mixed with a stable
+  # per-file value (cksum of the path) so different files get different orders
+  # while staying reproducible for the resolved seed.
+  if bashunit::env::is_random_order_enabled && [ "$functions_to_run_count" -gt 1 ]; then
+    local _base _crc _fn_seed
+    _base=$(bashunit::env::seed)
+    _crc=$(printf '%s' "$script" | cksum | cut -d' ' -f1)
+    _fn_seed=$(((_base + _crc) & 2147483647))
+    local -a _shuffled_fns=()
+    local _sfn
+    while IFS= read -r _sfn; do
+      [ -n "$_sfn" ] && _shuffled_fns[${#_shuffled_fns[@]}]=$_sfn
+    done < <(printf '%s\n' "${functions_to_run[@]+"${functions_to_run[@]}"}" | bashunit::math::shuffle "$_fn_seed")
+    functions_to_run=("${_shuffled_fns[@]+"${_shuffled_fns[@]}"}")
+    functions_to_run_count=${#functions_to_run[@]}
+  fi
+
+  if [ "$functions_to_run_count" -le 0 ]; then
+    return
+  fi
+
+  bashunit::helper::check_duplicate_functions "$script" || true
+
+  local -a provider_data=()
+  local provider_data_count=0
+  local -a parsed_data=()
+  local parsed_data_count=0
+
+  # Scan the file once; per-test provider lookups below are pure-bash (#763).
+  # The same pass also detects the no-parallel-tests opt-out (#774).
+  bashunit::helper::build_provider_map "$script"
+
+  local allow_test_parallel=true
+  if [ "$_BASHUNIT_PROVIDER_MAP_NO_PARALLEL" = true ]; then
+    allow_test_parallel=false
+  fi
+
+  # Pre-create the file's result dir before spawning test workers: they all
+  # publish into it, and checking `[ -d ]` inside a worker races its siblings
+  # (every worker would still pay the mkdir fork).
+  if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
+    local _suite_base="${script##*/}"
+    mkdir -p "${TEMP_DIR_PARALLEL_TEST_SUITE}/${_suite_base%.sh}" 2>/dev/null || true
+  fi
+
+  for fn_name in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
+    if bashunit::parallel::is_enabled && bashunit::parallel::must_stop_on_failure; then
+      break
+    fi
+
+    # No data provider found: run once without forking to capture provider output.
+    bashunit::helper::provider_for_function "$fn_name"
+    if [ -z "$_BASHUNIT_PROVIDER_FN_OUT" ]; then
+      if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
+        bashunit::runner::wait_for_job_slot
+        bashunit::runner::run_test "$script" "$fn_name" &
+      else
+        bashunit::runner::run_test "$script" "$fn_name"
+      fi
+      unset -v fn_name
+      continue
+    fi
+
+    provider_data=()
+    provider_data_count=0
+    local line
+    while IFS=" " read -r line; do
+      [ -z "$line" ] && continue
+      provider_data[provider_data_count]="$line"
+      provider_data_count=$((provider_data_count + 1))
+    done <<<"$(bashunit::helper::execute_function_if_exists "$_BASHUNIT_PROVIDER_FN_OUT")"
+
+    # Execute the test function for each line of data
+    local data
+    for data in "${provider_data[@]+"${provider_data[@]}"}"; do
+      parsed_data=()
+      parsed_data_count=0
+      local line
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        parsed_data[parsed_data_count]="$(bashunit::helper::decode_base64 "${line}")"
+        parsed_data_count=$((parsed_data_count + 1))
+      done <<<"$(bashunit::runner::parse_data_provider_args "$data")"
+      if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
+        bashunit::runner::wait_for_job_slot
+        bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"} &
+      else
+        bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"}
+      fi
+    done
+    unset -v fn_name
+  done
+
+  # Wait for all parallel tests within this file to complete
+  if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
+    wait
+  fi
+}
+
+function bashunit::runner::call_bench_functions() {
+  local script="$1"
+  local filter="$2"
+  local IFS=$' \t\n'
+  local prefix="bench"
+
+  # Use cached function names for better performance
+  local filtered_functions
+  filtered_functions=$(bashunit::helper::get_functions_to_run \
+    "$prefix" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
+  local -a functions_to_run=()
+  local functions_to_run_count=0
+  local _fn
+  while IFS= read -r _fn; do
+    [ -z "$_fn" ] && continue
+    functions_to_run[functions_to_run_count]="$_fn"
+    functions_to_run_count=$((functions_to_run_count + 1))
+  done < <(bashunit::runner::functions_for_script "$script" "$filtered_functions")
+
+  if [ "$functions_to_run_count" -le 0 ]; then
+    return
+  fi
+
+  if bashunit::env::is_bench_mode_enabled; then
+    bashunit::runner::render_running_file_header "$script"
+  fi
+
+  local fn_name
+  for fn_name in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
+    read -r revs its max_ms <<<"$(bashunit::benchmark::parse_annotations "$fn_name" "$script")"
+    bashunit::benchmark::run_function "$fn_name" "$revs" "$its" "$max_ms"
+    unset -v fn_name
+  done
+
+  if ! bashunit::env::is_simple_output_enabled; then
+    echo ""
+  fi
+}
+
+function bashunit::runner::render_running_file_header() {
+  local script="$1"
+  local force="${2:-false}"
+
+  bashunit::internal_log "Running file" "$script"
+
+  if [ "$force" != true ] && bashunit::parallel::is_enabled; then
+    return
+  fi
+
+  # Suppress file headers in failures-only mode
+  if bashunit::env::is_failures_only_enabled; then
+    return
+  fi
+
+  # Suppress file headers in no-progress mode
+  if bashunit::env::is_no_progress_enabled; then
+    return
+  fi
+
+  if bashunit::env::is_tap_output_enabled; then
+    printf "# %s\n" "$script"
+  elif ! bashunit::env::is_simple_output_enabled; then
+    if bashunit::env::is_verbose_enabled; then
+      printf "\n${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" "Running $script"
+    else
+      printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" "Running $script"
+    fi
+  elif bashunit::env::is_verbose_enabled; then
+    printf "\n\n${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}" "Running $script"
+  fi
+}
+
+# Result slots for the timeout-aware execution path (see run_with_timeout).
+_BASHUNIT_RUNNER_EXEC_OUT=""
+_BASHUNIT_RUNNER_TIMED_OUT="false"
+
+##
+# Runs a single test inside the capture subshell: sets up the EXIT trap that
+# encodes assertion counts/exit code, runs set_up, applies the shell mode and
+# finally invokes the test function. Meant to be called from a subshell (either
+# the `$(...)` capture or a backgrounded job), so its `set`/`trap`/`exit` calls
+# stay isolated. Emits the test stdout (with stderr merged) followed by the
+# encoded context from cleanup_on_exit.
+# Arguments: $1 test file, $2 function name, $@ test args
+##
+function bashunit::runner::execute_test_body() {
+  local test_file=$1
+  shift
+  local fn_name=$1
+  shift
+
+  # Save subshell stdout to FD 5 so the EXIT trap can restore it.
+  # When set -e kills the subshell during a redirected block in
+  # execute_test_hook, the redirect leaks into the EXIT trap,
+  # causing export_subshell_context output to be lost.
+  exec 5>&1
+  # shellcheck disable=SC2064
+  trap "exit_code=\$?; bashunit::runner::cleanup_on_exit \"$test_file\" \"\$exit_code\"" EXIT
+  bashunit::state::initialize_assertions_count
+
+  if bashunit::env::is_login_shell_enabled; then
+    bashunit::runner::source_login_shell_profiles
+  fi
+
+  # Enable coverage tracking early to include set_up/tear_down hooks
+  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
+    bashunit::coverage::enable_trap
+  fi
+
+  # Run set_up and capture exit code without || to preserve errexit behavior
+  # shellcheck disable=SC2030
+  _BASHUNIT_SETUP_COMPLETED=false
+  local setup_exit_code=0
+  bashunit::runner::run_set_up "$test_file"
+  setup_exit_code=$?
+  _BASHUNIT_SETUP_COMPLETED=true
+  if [ $setup_exit_code -ne 0 ]; then
+    exit $setup_exit_code
+  fi
+
+  # Apply shell mode setting for test execution
+  if bashunit::env::is_strict_mode_enabled; then
+    set -eu
+    # Bash 3.0 ships a broken pipefail; only enable it where it is reliable.
+    if bashunit::runner::_supports_reliable_pipefail; then
+      set -o pipefail
+    else
+      set +o pipefail
+    fi
+  else
+    set +euo pipefail
+  fi
+
+  # 2>&1: Redirects the std-error (FD 2) to the std-output (FD 1).
+  # points to the original std-output.
+  "$fn_name" "$@" 2>&1
+}
+
+##
+# Prints an encoded subshell result for a test that timed out: empty assertion
+# counters and exit code 124 (the conventional "timed out" code, already mapped
+# by classify_kill_signal). The empty TEST_HOOK_MESSAGE/TITLE/OUTPUT fields would
+# base64-encode to an empty string anyway, so the line is emitted directly rather
+# than mutating the shared _BASHUNIT_* globals (it mirrors the layout produced by
+# bashunit::state::export_subshell_context). Bash 3.0+ compatible.
+##
+function bashunit::runner::build_timeout_result() {
+  printf '%s' "##ASSERTIONS_FAILED=0##ASSERTIONS_PASSED=0##ASSERTIONS_SKIPPED=0\
+##ASSERTIONS_INCOMPLETE=0##ASSERTIONS_SNAPSHOT=0##TEST_EXIT_CODE=124\
+##TEST_HOOK_FAILURE=##TEST_HOOK_MESSAGE=##TEST_TITLE=##TEST_OUTPUT=##"
+}
+
+##
+# Runs the test body with a watchdog that kills it after BASHUNIT_TEST_TIMEOUT
+# seconds. The body runs as a backgrounded job in its own process group (set -m)
+# so the watchdog can SIGTERM/SIGKILL the whole tree — a hanging test usually
+# blocks in a child process, which signalling the subshell alone cannot reach.
+# Writes the captured result to _BASHUNIT_RUNNER_EXEC_OUT and "true"/"false" to
+# _BASHUNIT_RUNNER_TIMED_OUT. Bash 3.0+ compatible (validated on Bash 3.2).
+# Arguments: $1 test file, $2 function name, $@ test args
+##
+function bashunit::runner::run_with_timeout() {
+  local test_file=$1
+  shift
+  local fn_name=$1
+  shift
+  local secs
+  secs=$(bashunit::env::test_timeout_secs)
+
+  # NOTE: these must NOT use bashunit::temp_file — that prefixes the current
+  # test id, and cleanup_on_exit (run inside the test subshell) would unlink
+  # them via cleanup_testcase_temp_files before we read them back here.
+  local tmp_dir="${BASHUNIT_TEMP_DIR:-${TMPDIR:-/tmp}}"
+  local out_file marker_file
+  out_file="$("$MKTEMP" "$tmp_dir/bashunit_timeout_out.XXXXXXX")"
+  marker_file="$("$MKTEMP" "$tmp_dir/bashunit_timeout_marker.XXXXXXX")"
+  rm -f "$marker_file"
+
+  # Both jobs run in their own process group (set -m) so each can be killed as a
+  # whole tree. The body MUST run in an explicit ( ) subshell: a backgrounded { }
+  # group does not run its EXIT trap on normal completion, which would drop the
+  # encoded assertion context. The watchdog's fds are detached from the caller so
+  # a lingering `sleep` can never hold a captured stdout pipe open.
+  set -m
+  (bashunit::runner::execute_test_body "$test_file" "$fn_name" "$@") >"$out_file" 2>&1 &
+  local test_pid=$!
+  (
+    sleep "$secs"
+    # Only a still-running test can have timed out. Without this guard a watchdog
+    # that outlived a missed teardown (see below) would mark an already-finished
+    # fast test as timed out.
+    kill -0 "$test_pid" 2>/dev/null || exit 0
+    : >"$marker_file"
+    kill -TERM -"$test_pid" 2>/dev/null
+    sleep 0.3
+    kill -KILL -"$test_pid" 2>/dev/null
+  ) </dev/null >/dev/null 2>&1 &
+  local watchdog_pid=$!
+  set +m
+
+  wait "$test_pid" 2>/dev/null
+  # Stop the watchdog by its pid AND its group. `set -m` does not reliably make a
+  # backgrounded subshell a group leader in a non-interactive shell, so the
+  # group-only kill intermittently misses, letting the watchdog sleep its full
+  # timeout and fire against a test that already passed. The direct-pid signal is
+  # always deliverable; the group signal also reaps the `sleep` child.
+  kill -TERM "$watchdog_pid" 2>/dev/null
+  kill -TERM -"$watchdog_pid" 2>/dev/null
+  wait "$watchdog_pid" 2>/dev/null
+
+  if [ -f "$marker_file" ]; then
+    _BASHUNIT_RUNNER_TIMED_OUT="true"
+    _BASHUNIT_RUNNER_EXEC_OUT="$(bashunit::runner::build_timeout_result)"
+  else
+    _BASHUNIT_RUNNER_TIMED_OUT="false"
+    _BASHUNIT_RUNNER_EXEC_OUT="$(cat "$out_file" 2>/dev/null)"
+  fi
+
+  rm -f "$out_file" "$marker_file"
+}
+
+# Per-test duration is consumed by --profile, --verbose, report files, and the
+# execution-time display. When none are active we can skip the clock reads,
+# which matters when the clock forks an interpreter (#765).
+function bashunit::runner::needs_test_duration() {
+  bashunit::env::is_profile_enabled && return 0
+  bashunit::env::is_verbose_enabled && return 0
+  bashunit::reports::is_enabled && return 0
+  bashunit::env::is_show_execution_time_enabled && return 0
+  return 1
+}
+
+function bashunit::runner::run_test() {
+  local start_time=0
+
+  local test_file="$1"
+  shift
+  local fn_name="$1"
+  shift
+
+  bashunit::internal_log "Running test" "$fn_name" "$*"
+  bashunit::runner::export_test_identity "$test_file" "$fn_name"
+
+  bashunit::state::reset_test_title
+  bashunit::runner::apply_interpolated_title "$fn_name" "$@"
+  local interpolated_fn_name=$_BASHUNIT_RUNNER_INTERP_OUT
+  local current_assertions_failed="$_BASHUNIT_ASSERTIONS_FAILED"
+  local current_assertions_snapshot="$_BASHUNIT_ASSERTIONS_SNAPSHOT"
+  local current_assertions_incomplete="$_BASHUNIT_ASSERTIONS_INCOMPLETE"
+  local current_assertions_skipped="$_BASHUNIT_ASSERTIONS_SKIPPED"
+
+  # (FD = File Descriptor)
+  # Duplicate the current std-output (FD 1) and assigns it to FD 3.
+  # This means that FD 3 now points to wherever the std-output was pointing.
+  exec 3>&1
+
+  local test_execution_result
+  local timed_out="false"
+  bashunit::env::resolve_retry_count
+  local retry_max=$_BASHUNIT_RETRY_VALIDATED
+  local retries_used=0
+  local measure_duration=false
+  bashunit::runner::needs_test_duration && measure_duration=true
+  # Retry wraps ONLY execution: a failed attempt is judged from its encoded
+  # result without committing, so the parse/report/counter path below still runs
+  # exactly once (on the final attempt) and nothing is double-counted. Each fork
+  # in --parallel retries itself before writing its single .result file.
+  while :; do
+    if [ "$measure_duration" = true ]; then
+      bashunit::clock::now_to_slot
+      start_time=$_BASHUNIT_CLOCK_NOW_OUT
+    fi
+    if bashunit::env::is_test_timeout_enabled; then
+      bashunit::runner::run_with_timeout "$test_file" "$fn_name" "$@"
+      test_execution_result="$_BASHUNIT_RUNNER_EXEC_OUT"
+      timed_out="$_BASHUNIT_RUNNER_TIMED_OUT"
+    else
+      test_execution_result=$(bashunit::runner::execute_test_body "$test_file" "$fn_name" "$@")
+    fi
+
+    local attempt_runtime_output="${test_execution_result%%##ASSERTIONS_*}"
+    bashunit::runner::detect_runtime_error "$attempt_runtime_output"
+    local attempt_runtime_error=$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT
+    bashunit::runner::extract_result_counts "$test_execution_result"
+    # Mirror the commit-phase failure test exactly (runtime error, non-zero exit,
+    # or a failed assertion); snapshot/incomplete/skipped/risky are not failures.
+    if [ -z "$attempt_runtime_error" ] &&
+      [ "$_BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT" -eq 0 ] &&
+      [ "$_BASHUNIT_RUNNER_COUNTS_FAILED_OUT" -eq 0 ]; then
+      break
+    fi
+    [ "$retries_used" -ge "$retry_max" ] && break
+    retries_used=$((retries_used + 1))
+  done
+
+  # Closes FD 3, which was used temporarily to hold the original stdout.
+  exec 3>&-
+
+  local duration=0
+  if [ "$measure_duration" = true ]; then
+    bashunit::clock::now_to_slot
+    local end_time=$_BASHUNIT_CLOCK_NOW_OUT
+    duration=$(((end_time - start_time) / 1000000))
+  fi
+
+  if bashunit::env::is_profile_enabled; then
+    bashunit::runner::record_profile "$duration" "$interpolated_fn_name" "$test_file"
+  fi
+
+  if bashunit::env::is_verbose_enabled; then
+    bashunit::runner::print_verbose_test_summary \
+      "$test_file" "$fn_name" "$duration" "$test_execution_result"
+  fi
+
+  bashunit::runner::decode_subshell_output "$test_execution_result"
+  local subshell_output=$_BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT
+
+  if [ -n "$subshell_output" ]; then
+    bashunit::runner::extract_subshell_type "$subshell_output"
+    local type=$_BASHUNIT_RUNNER_TYPE_OUT
+    bashunit::runner::format_subshell_output "$subshell_output"
+    subshell_output=$_BASHUNIT_RUNNER_OUTPUT_OUT
+    if ! bashunit::env::is_failures_only_enabled; then
+      bashunit::state::print_line "$type" "$subshell_output"
+    fi
+  fi
+
+  # Reuse the final attempt's values (the loop always runs at least once and
+  # its locals persist in this function scope), instead of recomputing and
+  # forking detect_runtime_error a second time (#764).
+  local runtime_output=$attempt_runtime_output
+  local runtime_error=$attempt_runtime_error
+
+  # parse_result accumulates _BASHUNIT_TEST_EXIT_CODE; reset it so each test's
+  # exit code is read in isolation (a non-zero/timed-out test must not poison
+  # the next one).
+  _BASHUNIT_TEST_EXIT_CODE=0
+  bashunit::runner::parse_result "$fn_name" "$test_execution_result" "$@"
+
+  local test_exit_code="$_BASHUNIT_TEST_EXIT_CODE"
+
+  bashunit::runner::compute_total_assertions "$test_execution_result"
+  local total_assertions=$_BASHUNIT_RUNNER_TOTAL_OUT
+
+  bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_TITLE"
+  local encoded_test_title=$_BASHUNIT_RUNNER_FIELD_OUT
+  bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_HOOK_FAILURE"
+  local hook_failure=$_BASHUNIT_RUNNER_FIELD_OUT
+  bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_HOOK_MESSAGE"
+  local encoded_hook_message=$_BASHUNIT_RUNNER_FIELD_OUT
+
+  local test_title=""
+  [ -n "$encoded_test_title" ] && test_title="$(bashunit::helper::decode_base64 "$encoded_test_title")"
+  local hook_message=""
+  [ -n "$encoded_hook_message" ] && hook_message="$(bashunit::helper::decode_base64 "$encoded_hook_message")"
+
+  bashunit::set_test_title "$test_title"
+  bashunit::helper::normalize_test_function_name_to_slot "$fn_name" "$interpolated_fn_name"
+  local label=$_BASHUNIT_HELPER_NORMALIZED_OUT
+  bashunit::state::reset_test_title
+  bashunit::state::reset_current_test_interpolated_function_name
+
+  local failure_label="$label"
+  local failure_function="$fn_name"
+  if [ -n "$hook_failure" ]; then
+    bashunit::helper::normalize_test_function_name_to_slot "$hook_failure"
+    failure_label=$_BASHUNIT_HELPER_NORMALIZED_OUT
+    failure_function="$hook_failure"
+  fi
+
+  if [ -n "$runtime_error" ] || [ "$test_exit_code" -ne 0 ]; then
+    bashunit::state::add_tests_failed
+    bashunit::rerun::record "$test_file" "$fn_name"
+    local error_message="$runtime_error"
+    if [ -n "$hook_failure" ] && [ -n "$hook_message" ]; then
+      error_message="$hook_message"
+    elif [ -z "$error_message" ] && [ -n "$hook_message" ]; then
+      error_message="$hook_message"
+    fi
+
+    # When the test was killed by a signal (or timed out), replace an empty or
+    # generic "Killed" message with a specific cause.
+    if [ -z "$hook_failure" ]; then
+      local kill_message
+      kill_message=$(bashunit::runner::classify_kill_signal "$test_exit_code")
+      if [ -n "$kill_message" ]; then
+        case "$error_message" in
+        '' | *[Kk]illed* | *[Tt]erminated*) error_message="$kill_message" ;;
+        esac
+      fi
+    fi
+
+    # A test that exceeded BASHUNIT_TEST_TIMEOUT gets a clear, specific message.
+    if [ "$timed_out" = "true" ]; then
+      error_message="Test timed out after $(bashunit::env::test_timeout_secs)s"
+    fi
+
+    bashunit::console_results::print_error_test "$failure_function" "$error_message" "$runtime_output"
+    bashunit::reports::add_test_failed "$test_file" "$failure_label" "$duration" "$total_assertions" "$error_message"
+    bashunit::runner::write_failure_result_output "$test_file" "$failure_function" "$error_message" "$runtime_output"
+    bashunit::internal_log "Test error" "$failure_label" "$error_message"
+
+    if bashunit::env::is_stop_on_failure_enabled; then
+      if bashunit::parallel::is_enabled; then
+        bashunit::parallel::mark_stop_on_failure
+      else
+        exit "$EXIT_CODE_STOP_ON_FAILURE"
+      fi
+    fi
+    return
+  fi
+
+  if [ "$current_assertions_failed" != "$_BASHUNIT_ASSERTIONS_FAILED" ]; then
+    bashunit::state::add_tests_failed
+    bashunit::rerun::record "$test_file" "$fn_name"
+    bashunit::reports::add_test_failed "$test_file" "$label" "$duration" "$total_assertions" "$subshell_output"
+    local assertion_runtime_output
+    assertion_runtime_output="$(
+      bashunit::runner::extract_assertion_runtime_output "$runtime_output" "$subshell_output"
+    )"
+    bashunit::runner::write_failure_result_output \
+      "$test_file" "$fn_name" "$subshell_output" "$assertion_runtime_output"
+
+    bashunit::internal_log "Test failed" "$label"
+
+    if bashunit::env::is_stop_on_failure_enabled; then
+      if bashunit::parallel::is_enabled; then
+        bashunit::parallel::mark_stop_on_failure
+      else
+        exit "$EXIT_CODE_STOP_ON_FAILURE"
+      fi
+    fi
+    return
+  fi
+
+  if [ "$current_assertions_snapshot" != "$_BASHUNIT_ASSERTIONS_SNAPSHOT" ]; then
+    bashunit::state::add_tests_snapshot
+    # In failures-only mode, suppress snapshot test output
+    if ! bashunit::env::is_failures_only_enabled; then
+      bashunit::console_results::print_snapshot_test "$label"
+    fi
+    bashunit::reports::add_test_snapshot "$test_file" "$label" "$duration" "$total_assertions"
+    bashunit::internal_log "Test snapshot" "$label"
+    return
+  fi
+
+  if [ "$current_assertions_incomplete" != "$_BASHUNIT_ASSERTIONS_INCOMPLETE" ]; then
+    bashunit::state::add_tests_incomplete
+    bashunit::reports::add_test_incomplete "$test_file" "$label" "$duration" "$total_assertions"
+    bashunit::runner::write_incomplete_result_output "$test_file" "$fn_name" "$subshell_output"
+    bashunit::internal_log "Test incomplete" "$label"
+    return
+  fi
+
+  if [ "$current_assertions_skipped" != "$_BASHUNIT_ASSERTIONS_SKIPPED" ]; then
+    bashunit::state::add_tests_skipped
+    bashunit::reports::add_test_skipped "$test_file" "$label" "$duration" "$total_assertions"
+    bashunit::runner::write_skipped_result_output "$test_file" "$fn_name" "$subshell_output"
+    bashunit::internal_log "Test skipped" "$label"
+    return
+  fi
+
+  # Check for risky test (zero assertions)
+  if [ "$total_assertions" -eq 0 ]; then
+    if bashunit::env::is_fail_on_risky_enabled; then
+      local risky_msg="Test has no assertions (risky)"
+      bashunit::state::add_tests_failed
+      bashunit::rerun::record "$test_file" "$fn_name"
+      bashunit::console_results::print_error_test "$fn_name" "$risky_msg"
+      bashunit::reports::add_test_failed "$test_file" "$label" "$duration" "$total_assertions" "$risky_msg"
+      bashunit::runner::write_failure_result_output "$test_file" "$fn_name" "$risky_msg"
+      bashunit::internal_log "Test failed (risky)" "$label"
+      if bashunit::env::is_stop_on_failure_enabled; then
+        if bashunit::parallel::is_enabled; then
+          bashunit::parallel::mark_stop_on_failure
+        else
+          exit "$EXIT_CODE_STOP_ON_FAILURE"
+        fi
+      fi
+      return
+    fi
+    bashunit::state::add_tests_risky
+    if ! bashunit::env::is_failures_only_enabled; then
+      bashunit::console_results::print_risky_test "${label}" "$duration"
+    fi
+    bashunit::reports::add_test_risky "$test_file" "$label" "$duration" "$total_assertions"
+    bashunit::runner::write_risky_result_output "$test_file" "$fn_name"
+    bashunit::internal_log "Test risky" "$label"
+    return
+  fi
+
+  # A test that only passed after retrying is annotated so flakiness stays visible.
+  _BASHUNIT_RETRY_NOTE=""
+  if [ "$retries_used" -gt 0 ]; then
+    _BASHUNIT_RETRY_NOTE=" (retry $retries_used/$retry_max)"
+  fi
+  # In failures-only mode, suppress successful test output
+  if ! bashunit::env::is_failures_only_enabled; then
+    if [ "$fn_name" = "$interpolated_fn_name" ]; then
+      bashunit::console_results::print_successful_test "${label}" "$duration" "$@"
+    else
+      bashunit::console_results::print_successful_test "${label}" "$duration"
+    fi
+  fi
+  _BASHUNIT_RETRY_NOTE=""
+  bashunit::state::add_tests_passed
+  bashunit::reports::add_test_passed "$test_file" "$label" "$duration" "$total_assertions"
+  bashunit::internal_log "Test passed" "$label"
+}
+
+function bashunit::runner::cleanup_on_exit() {
+  local test_file="$1"
+  local exit_code="$2"
+
+  # Disable coverage trap before cleanup to avoid interference
+  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
+    bashunit::coverage::disable_trap
+  fi
+
+  set +e
+
+  # Detect unexpected subshell exit during set_up (Issue #611).
+  # When 'source' of a non-existent file fails under set -eE, the ERR trap
+  # does not fire. On macOS Bash 3.2, $? is 0 in the EXIT trap; on Linux
+  # Bash 5.x, $? is 1. In both cases the hook failure is not recorded.
+  # Additionally, the stdout redirect from execute_test_hook leaks into the
+  # EXIT trap. Restore stdout from saved FD 5 so export_subshell_context
+  # output reaches test_execution_result.
+  # shellcheck disable=SC2031
+  if [ "${_BASHUNIT_SETUP_COMPLETED:-true}" != "true" ]; then
+    exec 1>&5
+    if [ "$exit_code" -eq 0 ]; then
+      exit_code=1
+    fi
+    if [ -z "${_BASHUNIT_TEST_HOOK_FAILURE:-}" ]; then
+      bashunit::state::set_test_hook_failure "set_up"
+      bashunit::state::set_test_hook_message "Hook 'set_up' failed unexpectedly (e.g., source of non-existent file)"
+    fi
+  fi
+
+  # Don't use || here - it disables ERR trap in the entire call chain
+  bashunit::runner::run_tear_down "$test_file"
+  local teardown_status=$?
+  bashunit::runner::clear_mocks
+  bashunit::cleanup_testcase_temp_files
+
+  if [ $teardown_status -ne 0 ]; then
+    bashunit::state::set_test_exit_code "$teardown_status"
+  else
+    bashunit::state::set_test_exit_code "$exit_code"
+  fi
+
+  bashunit::state::export_subshell_context
+}
+
+# Writes the decoded subshell output into _BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT.
+# The empty case (a passing test with no captured output) short-circuits with
+# no subshell at all; only the non-empty path pays the base64 fork (#762/#764).
+# Arguments: $1 test_execution_result
+function bashunit::runner::decode_subshell_output() {
+  local test_execution_result="$1"
+
+  local test_output_base64="${test_execution_result##*##TEST_OUTPUT=}"
+  test_output_base64="${test_output_base64%%##*}"
+  if [ -z "$test_output_base64" ] || [ "$test_output_base64" = "_BASHUNIT_EMPTY_" ]; then
+    _BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT=""
+    return
+  fi
+  _BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT="$(bashunit::helper::decode_base64 "$test_output_base64")"
+}
+
+function bashunit::runner::is_simple_progress_output() {
+  local output="$1"
+
+  [ -n "$output" ] || return 1
+
+  local color
+  for color in \
+    "$_BASHUNIT_COLOR_DEFAULT" \
+    "$_BASHUNIT_COLOR_PASSED" \
+    "$_BASHUNIT_COLOR_FAILED" \
+    "$_BASHUNIT_COLOR_SKIPPED" \
+    "$_BASHUNIT_COLOR_INCOMPLETE" \
+    "$_BASHUNIT_COLOR_SNAPSHOT" \
+    "$_BASHUNIT_COLOR_RISKY"; do
+    [ -n "$color" ] && output="${output//"$color"/}"
+  done
+
+  local i
+  local char
+  for ((i = 0; i < ${#output}; i++)); do
+    char="${output:$i:1}"
+    case "$char" in
+    "." | "F" | "S" | "I" | "N" | "R" | "E" | "?") ;;
+    *) return 1 ;;
+    esac
+  done
+
+  return 0
+}
+
+function bashunit::runner::line_exists_in_output() {
+  local needle="$1"
+  local haystack="$2"
+  local line
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ "$line" = "$needle" ] && return 0
+  done <<<"$haystack"
+
+  return 1
+}
+
+function bashunit::runner::extract_assertion_runtime_output() {
+  local runtime_output="$1"
+  local rendered_assertion_output="$2"
+  local filtered_output=""
+  local line
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if bashunit::runner::line_exists_in_output "$line" "$rendered_assertion_output"; then
+      continue
+    fi
+    if bashunit::runner::is_simple_progress_output "$line"; then
+      continue
+    fi
+
+    [ -n "$filtered_output" ] && filtered_output="$filtered_output"$'\n'
+    filtered_output="$filtered_output$line"
+  done <<<"$runtime_output"
+
+  runtime_output="$filtered_output"
+
+  while [ -n "$runtime_output" ]; do
+    case "$runtime_output" in
+    *$'\n') runtime_output="${runtime_output%$'\n'}" ;;
+    *) break ;;
+    esac
+  done
+
+  echo "$runtime_output"
+}
+
+function bashunit::runner::parse_result() {
+  local fn_name=$1
+  shift
+  local execution_result=$1
+  shift
+  local IFS=$' \t\n'
+  local -a args
+  args=("$@")
+
+  if bashunit::parallel::is_enabled; then
+    bashunit::runner::parse_result_parallel "$fn_name" "$execution_result" ${args+"${args[@]}"}
+  else
+    bashunit::runner::parse_result_sync "$fn_name" "$execution_result"
+  fi
+}
+
+function bashunit::runner::parse_result_parallel() {
+  local fn_name=$1
+  shift
+  local execution_result=$1
+  shift
+  local IFS=$' \t\n'
+  local -a args
+  args=("$@")
+
+  # This runs once per test in every parallel worker, so avoid per-test forks:
+  # derive the suite dir name with parameter expansion (no basename), only
+  # mkdir when the dir is missing (first test of the file wins the race,
+  # `-p` makes the losers no-ops), and skip arg sanitizing entirely for the
+  # common no-provider-args case.
+  local test_suite_base="${test_file##*/}"
+  local test_suite_dir="${TEMP_DIR_PARALLEL_TEST_SUITE}/${test_suite_base%.sh}"
+  [ -d "$test_suite_dir" ] || mkdir -p "$test_suite_dir"
+
+  local sanitized_args=""
+  if [ -n "${args[*]+"${args[*]}"}" ]; then
+    sanitized_args=$(echo "${args[*]}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//')
+  fi
+  local template
+  if [ -z "$sanitized_args" ]; then
+    template="${fn_name}.XXXXXX"
+  else
+    template="${fn_name}-${sanitized_args}.XXXXXX"
+  fi
+
+  local unique_test_result_file
+  if unique_test_result_file=$("$MKTEMP" -p "$test_suite_dir" "$template" 2>/dev/null); then
+    true
+  else
+    unique_test_result_file=$("$MKTEMP" "$test_suite_dir/$template")
+  fi
+  mv "$unique_test_result_file" "${unique_test_result_file}.result"
+  unique_test_result_file="${unique_test_result_file}.result"
+
+  bashunit::internal_log "[PARA]" "fn_name:$fn_name" "execution_result:$execution_result"
+
+  bashunit::runner::parse_result_sync "$fn_name" "$execution_result"
+
+  echo "$execution_result" >"$unique_test_result_file"
+}
+
+# shellcheck disable=SC2295
+##
+# Parses the encoded per-test result's last line into the counts out-slots
+# (_BASHUNIT_RUNNER_COUNTS_*_OUT). Pure read: never mutates the cumulative
+# _BASHUNIT_ASSERTIONS_* / _BASHUNIT_TEST_EXIT_CODE state, so the retry loop can
+# judge an attempt's outcome without committing it.
+##
+function bashunit::runner::extract_result_counts() {
+  local execution_result=$1
+
+  local result_line
+  result_line="${execution_result##*$'\n'}"
+
+  local assertions_failed=0
+  local assertions_passed=0
+  local assertions_skipped=0
+  local assertions_incomplete=0
+  local assertions_snapshot=0
+  local test_exit_code=0
+
+  # Extract values using parameter expansion instead of spawning grep/sed subprocesses
+  case "$result_line" in
+  *"ASSERTIONS_FAILED="*"##ASSERTIONS_PASSED="*)
+    local _tail
+    _tail="${result_line##*ASSERTIONS_FAILED=}"
+    assertions_failed="${_tail%%##*}"
+    _tail="${result_line##*ASSERTIONS_PASSED=}"
+    assertions_passed="${_tail%%##*}"
+    _tail="${result_line##*ASSERTIONS_SKIPPED=}"
+    assertions_skipped="${_tail%%##*}"
+    _tail="${result_line##*ASSERTIONS_INCOMPLETE=}"
+    assertions_incomplete="${_tail%%##*}"
+    _tail="${result_line##*ASSERTIONS_SNAPSHOT=}"
+    assertions_snapshot="${_tail%%##*}"
+    _tail="${result_line##*TEST_EXIT_CODE=}"
+    test_exit_code="${_tail%%##*}"
+    # Strip any trailing non-digit suffix (end of line) from the final field
+    test_exit_code="${test_exit_code%%[!0-9]*}"
+    : "${assertions_failed:=0}"
+    : "${assertions_passed:=0}"
+    : "${assertions_skipped:=0}"
+    : "${assertions_incomplete:=0}"
+    : "${assertions_snapshot:=0}"
+    : "${test_exit_code:=0}"
+    ;;
+  esac
+
+  _BASHUNIT_RUNNER_COUNTS_FAILED_OUT=$assertions_failed
+  _BASHUNIT_RUNNER_COUNTS_PASSED_OUT=$assertions_passed
+  _BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT=$assertions_skipped
+  _BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT=$assertions_incomplete
+  _BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT=$assertions_snapshot
+  _BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT=$test_exit_code
+}
+
+function bashunit::runner::parse_result_sync() {
+  local fn_name=$1
+  local execution_result=$2
+
+  bashunit::runner::extract_result_counts "$execution_result"
+
+  bashunit::internal_log "[SYNC]" "fn_name:$fn_name" "execution_result:$execution_result"
+
+  _BASHUNIT_ASSERTIONS_PASSED=$((_BASHUNIT_ASSERTIONS_PASSED + _BASHUNIT_RUNNER_COUNTS_PASSED_OUT))
+  _BASHUNIT_ASSERTIONS_FAILED=$((_BASHUNIT_ASSERTIONS_FAILED + _BASHUNIT_RUNNER_COUNTS_FAILED_OUT))
+  _BASHUNIT_ASSERTIONS_SKIPPED=$((_BASHUNIT_ASSERTIONS_SKIPPED + _BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT))
+  _BASHUNIT_ASSERTIONS_INCOMPLETE=$((_BASHUNIT_ASSERTIONS_INCOMPLETE + _BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT))
+  _BASHUNIT_ASSERTIONS_SNAPSHOT=$((_BASHUNIT_ASSERTIONS_SNAPSHOT + _BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT))
+  _BASHUNIT_TEST_EXIT_CODE=$((_BASHUNIT_TEST_EXIT_CODE + _BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT))
+
+  bashunit::internal_log "result_summary" \
+    "failed:$_BASHUNIT_RUNNER_COUNTS_FAILED_OUT" \
+    "passed:$_BASHUNIT_RUNNER_COUNTS_PASSED_OUT" \
+    "skipped:$_BASHUNIT_RUNNER_COUNTS_SKIPPED_OUT" \
+    "incomplete:$_BASHUNIT_RUNNER_COUNTS_INCOMPLETE_OUT" \
+    "snapshot:$_BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT" \
+    "exit_code:$_BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT"
+}
+
+function bashunit::runner::write_failure_result_output() {
+  local test_file=$1
+  local fn_name=$2
+  local error_msg=$3
+  local raw_output="${4:-}"
+
+  local line_number
+  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
+
+  local test_nr="*"
+  if ! bashunit::parallel::is_enabled; then
+    test_nr=$(bashunit::state::get_tests_failed)
+  fi
+
+  local output_section=""
+  if [ -n "$raw_output" ] && bashunit::env::is_show_output_on_failure_enabled; then
+    output_section="\n    Output:\n$raw_output"
+  fi
+
+  local source_context=""
+  if [ -n "$line_number" ] && [ -f "$test_file" ]; then
+    source_context=$(bashunit::runner::get_failure_source_context \
+      "$test_file" "$line_number")
+  fi
+
+  echo -e "$test_nr) $test_file:$line_number\n$error_msg$output_section$source_context" \
+    >>"$FAILURES_OUTPUT_PATH"
+}
+
+function bashunit::runner::get_failure_source_context() {
+  local file=$1
+  local fn_line=$2
+
+  # Read the file once (a bash builtin loop) instead of forking `sed` to fetch
+  # each line and `grep` to test each line for the closing brace. The fork count
+  # no longer grows with the function length.
+  local line_text line_num=0 assert_lines="" stripped trimmed
+  while IFS= read -r line_text || [ -n "$line_text" ]; do
+    line_num=$((line_num + 1))
+    # Skip everything up to and including the function definition line.
+    if [ "$line_num" -le "$fn_line" ]; then
+      continue
+    fi
+    # Stop at the closing brace of the function (a line that is only `}`).
+    stripped="${line_text#"${line_text%%[![:space:]]*}"}"
+    stripped="${stripped%"${stripped##*[![:space:]]}"}"
+    if [ "$stripped" = "}" ]; then
+      break
+    fi
+    # Collect lines containing assert calls
+    case "$line_text" in
+    *assert_* | *assert\ *)
+      trimmed="${line_text#"${line_text%%[![:space:]]*}"}"
+      assert_lines="${assert_lines}\n    ${_BASHUNIT_COLOR_FAINT}${line_num}:${_BASHUNIT_COLOR_DEFAULT} ${trimmed}"
+      ;;
+    esac
+  done <"$file"
+
+  if [ -n "$assert_lines" ]; then
+    echo -e "\n    ${_BASHUNIT_COLOR_FAINT}Source:${_BASHUNIT_COLOR_DEFAULT}${assert_lines}"
+  fi
+}
+
+function bashunit::runner::write_skipped_result_output() {
+  local test_file=$1
+  local fn_name=$2
+  local output_msg=$3
+
+  local line_number
+  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
+
+  local test_nr="*"
+  if ! bashunit::parallel::is_enabled; then
+    test_nr=$(bashunit::state::get_tests_skipped)
+  fi
+
+  echo -e "$test_nr) $test_file:$line_number\n$output_msg" >>"$SKIPPED_OUTPUT_PATH"
+}
+
+function bashunit::runner::write_incomplete_result_output() {
+  local test_file=$1
+  local fn_name=$2
+  local output_msg=$3
+
+  local line_number
+  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
+
+  local test_nr="*"
+  if ! bashunit::parallel::is_enabled; then
+    test_nr=$(bashunit::state::get_tests_incomplete)
+  fi
+
+  echo -e "$test_nr) $test_file:$line_number\n$output_msg" >>"$INCOMPLETE_OUTPUT_PATH"
+}
+
+function bashunit::runner::write_risky_result_output() {
+  local test_file=$1
+  local fn_name=$2
+
+  local line_number
+  line_number=$(bashunit::helper::get_function_line_number "$fn_name")
+
+  local test_nr="*"
+  if ! bashunit::parallel::is_enabled; then
+    test_nr=$(bashunit::state::get_tests_risky)
+  fi
+
+  echo -e "$test_nr) $test_file:$line_number\nTest has no assertions (risky)" >>"$RISKY_OUTPUT_PATH"
+}
+
+function bashunit::runner::record_file_hook_failure() {
+  local hook_name="$1"
+  local test_file="$2"
+  local hook_output="$3"
+  local status="$4"
+  local render_header="${5:-false}"
+
+  if [ "$render_header" = true ]; then
+    bashunit::runner::render_running_file_header "$test_file" true
+  fi
+
+  if [ -z "$hook_output" ]; then
+    hook_output="Hook '$hook_name' failed with exit code $status"
+  fi
+
+  bashunit::state::add_tests_failed
+  bashunit::console_results::print_error_test "$hook_name" "$hook_output"
+  local _normalized_hook
+  _normalized_hook="$(bashunit::helper::normalize_test_function_name "$hook_name")"
+  bashunit::reports::add_test_failed "$test_file" "$_normalized_hook" 0 0 "$hook_output"
+  bashunit::runner::write_failure_result_output "$test_file" "$hook_name" "$hook_output"
+
+  return "$status"
+}
+
+function bashunit::runner::execute_file_hook() {
+  local hook_name="$1"
+  local test_file="$2"
+  local render_header="${3:-false}"
+
+  declare -F "$hook_name" >/dev/null 2>&1 || return 0
+
+  local hook_output=""
+  local status=0
+  local hook_output_file
+  hook_output_file=$(bashunit::temp_file "${hook_name}_output")
+
+  # Enable errtrace to catch any failing command in the hook.
+  # Using -E (errtrace) without -e (errexit) prevents the main process from
+  # exiting on source failures (Bash 3.2 doesn't trigger ERR trap with -eE).
+  # The ERR trap saves the exit status to a global variable, cleans up shell
+  # options, and returns from the hook function to prevent subsequent commands
+  # from executing.
+  # Variables set before the failure are preserved since we don't use a subshell.
+  _BASHUNIT_HOOK_ERR_STATUS=0
+  set -E
+  if bashunit::env::is_strict_mode_enabled; then
+    set -uo pipefail
+  fi
+  # The trap returns from the function where the failure occurred (early-exit
+  # semantics for intermediate failing commands) — but only when that frame is
+  # NOT this executor: on Bash >= 4 the trap also fires HERE when the hook call
+  # itself returns non-zero, and an unconditional return skipped
+  # record_file_hook_failure entirely (silent failures, off-by-one counts, #836).
+  # shellcheck disable=SC2154
+  trap '_BASHUNIT_HOOK_ERR_STATUS=$?
+    if [ "${FUNCNAME[0]:-}" != "bashunit::runner::execute_file_hook" ]; then
+      set +Eu +o pipefail
+      trap - ERR
+      return $_BASHUNIT_HOOK_ERR_STATUS
+    fi' ERR
+
+  {
+    "$hook_name"
+  } >"$hook_output_file" 2>&1
+  # Real exit status of the hook, read from $? (this function runs without -e,
+  # so a failing compound does not exit). The ERR-trap global alone is not
+  # enough: a hook ending in a failing `cmd && var=x` guard returns non-zero
+  # without ever firing the trap (&& lists are ERR-exempt), which silently
+  # swallowed the failure (#836).
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    status=$_BASHUNIT_HOOK_ERR_STATUS
+  fi
+
+  trap - ERR
+  set +Eu +o pipefail
+
+  if [ -f "$hook_output_file" ]; then
+    hook_output=""
+    local line
+    while IFS= read -r line; do
+      [ -z "$hook_output" ] && hook_output="$line" || hook_output="$hook_output"$'\n'"$line"
+    done <"$hook_output_file"
+    rm -f "$hook_output_file"
+  fi
+
+  if [ $status -ne 0 ]; then
+    bashunit::runner::record_file_hook_failure "$hook_name" "$test_file" "$hook_output" "$status" "$render_header"
+    return $status
+  fi
+
+  if [ -n "$hook_output" ] && bashunit::env::is_verbose_enabled; then
+    printf "%s\n" "$hook_output"
+  fi
+
+  return 0
+}
+
+function bashunit::runner::run_set_up() {
+  local _test_file="${1-}"
+  bashunit::internal_log "run_set_up"
+  bashunit::runner::execute_test_hook 'set_up'
+}
+
+function bashunit::runner::run_set_up_before_script() {
+  local test_file="$1"
+  bashunit::internal_log "run_set_up_before_script"
+
+  # Check if hook exists first
+  if ! declare -F "set_up_before_script" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local start_time
+  start_time=$(bashunit::clock::now)
+
+  # Enable coverage trap to attribute lines executed during set_up_before_script
+  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
+    bashunit::coverage::enable_trap
+  fi
+
+  # Execute the hook (render_header=false since header is already rendered)
+  bashunit::runner::execute_file_hook 'set_up_before_script' "$test_file" false
+  local status=$?
+
+  # Disable coverage trap after hook execution
+  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
+    bashunit::coverage::disable_trap
+  fi
+
+  local end_time
+  end_time=$(bashunit::clock::now)
+  local duration_ns=$((end_time - start_time))
+  local duration_ms=$((duration_ns / 1000000))
+
+  # Print completion message only if hook succeeded
+  if [ $status -eq 0 ]; then
+    bashunit::console_results::print_hook_completed "set_up_before_script" "$duration_ms"
+  fi
+
+  return $status
+}
+
+function bashunit::runner::run_tear_down() {
+  local _test_file="${1-}"
+  bashunit::internal_log "run_tear_down"
+  bashunit::runner::execute_test_hook 'tear_down'
+}
+
+function bashunit::runner::execute_test_hook() {
+  local hook_name="$1"
+
+  declare -F "$hook_name" >/dev/null 2>&1 || return 0
+
+  local hook_output=""
+  local status=0
+  local hook_output_file
+  hook_output_file=$(bashunit::temp_file "${hook_name}_output")
+
+  # Enable errtrace to catch any failing command in the hook.
+  # Using -E (errtrace) without -e (errexit) prevents the subshell from
+  # exiting on source failures (Bash 3.2 doesn't trigger ERR trap with -eE).
+  # The ERR trap saves the exit status to a global variable, cleans up shell
+  # options, and returns from the hook function to prevent subsequent commands
+  # from executing.
+  # Variables set before the failure are preserved since we don't use a subshell.
+  _BASHUNIT_HOOK_ERR_STATUS=0
+  set -E
+  if bashunit::env::is_strict_mode_enabled; then
+    set -uo pipefail
+  fi
+  # See the twin comment in execute_file_hook: conditional return keeps the
+  # early-exit semantics for intermediate failures without silently returning
+  # from THIS executor when the trap re-fires here on Bash >= 4 (#836).
+  # shellcheck disable=SC2154
+  trap '_BASHUNIT_HOOK_ERR_STATUS=$?
+    if [ "${FUNCNAME[0]:-}" != "bashunit::runner::execute_test_hook" ]; then
+      set +Eu +o pipefail
+      trap - ERR
+      return $_BASHUNIT_HOOK_ERR_STATUS
+    fi' ERR
+
+  {
+    "$hook_name"
+  } >"$hook_output_file" 2>&1
+  # Real hook status from $?; the trap global alone misses failing
+  # `cmd && var=x` guards (&& lists are ERR-exempt) (#836).
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    status=$_BASHUNIT_HOOK_ERR_STATUS
+  fi
+
+  trap - ERR
+  set +Eu +o pipefail
+
+  if [ -f "$hook_output_file" ]; then
+    hook_output=""
+    local line
+    while IFS= read -r line; do
+      [ -z "$hook_output" ] && hook_output="$line" || hook_output="$hook_output"$'\n'"$line"
+    done <"$hook_output_file"
+    rm -f "$hook_output_file"
+  fi
+
+  if [ $status -ne 0 ]; then
+    local message="$hook_output"
+    if [ -n "$hook_output" ]; then
+      printf "%s" "$hook_output"
+    else
+      message="Hook '$hook_name' failed with exit code $status"
+      printf "%s\n" "$message" >&2
+    fi
+    bashunit::runner::record_test_hook_failure "$hook_name" "$message" "$status"
+    return "$status"
+  fi
+
+  if [ -n "$hook_output" ]; then
+    printf "%s" "$hook_output"
+  fi
+
+  return 0
+}
+
+function bashunit::runner::record_test_hook_failure() {
+  local hook_name="$1"
+  local hook_message="$2"
+  local status="$3"
+
+  if [ -n "$_BASHUNIT_TEST_HOOK_FAILURE" ]; then
+    return "$status"
+  fi
+
+  bashunit::state::set_test_hook_failure "$hook_name"
+  bashunit::state::set_test_hook_message "$hook_message"
+
+  return "$status"
+}
+
+function bashunit::runner::clear_mocks() {
+  if [ "${#_BASHUNIT_MOCKED_FUNCTIONS[@]}" -eq 0 ]; then
+    return
+  fi
+
+  local i
+  for i in "${!_BASHUNIT_MOCKED_FUNCTIONS[@]}"; do
+    bashunit::unmock "${_BASHUNIT_MOCKED_FUNCTIONS[$i]:-}"
+  done
+}
+
+function bashunit::runner::run_tear_down_after_script() {
+  local test_file="$1"
+  bashunit::internal_log "run_tear_down_after_script"
+
+  # Check if hook exists first
+  if ! declare -F "tear_down_after_script" >/dev/null 2>&1; then
+    # Add blank line after tests if no tear_down hook
+    if ! bashunit::env::is_simple_output_enabled &&
+      ! bashunit::env::is_failures_only_enabled &&
+      ! bashunit::env::is_no_progress_enabled &&
+      ! bashunit::parallel::is_enabled; then
+      echo ""
+    fi
+    return 0
+  fi
+
+  local start_time
+  start_time=$(bashunit::clock::now)
+
+  # Enable coverage trap to attribute lines executed during tear_down_after_script
+  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
+    bashunit::coverage::enable_trap
+  fi
+
+  # Execute the hook
+  bashunit::runner::execute_file_hook 'tear_down_after_script' "$test_file"
+  local status=$?
+
+  # Disable coverage trap after hook execution
+  if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
+    bashunit::coverage::disable_trap
+  fi
+
+  local end_time
+  end_time=$(bashunit::clock::now)
+  local duration_ns=$((end_time - start_time))
+  local duration_ms=$((duration_ns / 1000000))
+
+  # Print completion message only if hook succeeded
+  if [ $status -eq 0 ]; then
+    bashunit::console_results::print_hook_completed "tear_down_after_script" "$duration_ms"
+  fi
+
+  # Add blank line after tear_down output
+  if ! bashunit::env::is_simple_output_enabled &&
+    ! bashunit::env::is_failures_only_enabled &&
+    ! bashunit::env::is_no_progress_enabled &&
+    ! bashunit::parallel::is_enabled; then
+    echo ""
+  fi
+
+  return $status
+}
+
+##
+# Unset a file's test functions once the file has been processed.
+#
+# Test files are sourced into the main shell, and their functions used to stay
+# defined for the whole run: every test's $() subshell then forked an
+# ever-growing shell, making multi-file runs quadratic in file count (#829).
+# In parallel mode the file's workers have already forked (with their own copy
+# of the functions) by the time this runs, so unsetting here is race-free.
+# Arguments: $1 - whitespace-separated test function names
+##
+function bashunit::runner::clean_script_test_functions() {
+  local IFS=$' \t\n'
+  local fn
+  for fn in $1; do
+    unset -f "$fn" 2>/dev/null || true
+  done
+}
+
+function bashunit::runner::clean_set_up_and_tear_down_after_script() {
+  bashunit::internal_log "clean_set_up_and_tear_down_after_script"
+  bashunit::helper::unset_if_exists 'set_up'
+  bashunit::helper::unset_if_exists 'tear_down'
+  bashunit::helper::unset_if_exists 'set_up_before_script'
+  bashunit::helper::unset_if_exists 'tear_down_after_script'
+}
+
+# benchmark.sh
+
+_BASHUNIT_BENCH_NAMES=()
+_BASHUNIT_BENCH_REVS=()
+_BASHUNIT_BENCH_ITS=()
+_BASHUNIT_BENCH_AVERAGES=()
+_BASHUNIT_BENCH_MAX_MILLIS=()
+
+function bashunit::benchmark::parse_annotations() {
+  local fn_name=$1
+  local script=$2
+  local revs=1
+  local its=1
+  local max_ms=""
+
+  local annotation
+  annotation=$(awk "/function[[:space:]]+${fn_name}[[:space:]]*\(/ {print prev; exit} {prev=\$0}" "$script")
+
+  local _extracted
+  _extracted=$(echo "$annotation" | sed -n 's/.*@revs=\([0-9][0-9]*\).*/\1/p')
+  if [ -n "$_extracted" ]; then
+    revs="$_extracted"
+  else
+    _extracted=$(echo "$annotation" | sed -n 's/.*@revolutions=\([0-9][0-9]*\).*/\1/p')
+    if [ -n "$_extracted" ]; then
+      revs="$_extracted"
+    fi
+  fi
+
+  _extracted=$(echo "$annotation" | sed -n 's/.*@its=\([0-9][0-9]*\).*/\1/p')
+  if [ -n "$_extracted" ]; then
+    its="$_extracted"
+  else
+    _extracted=$(echo "$annotation" | sed -n 's/.*@iterations=\([0-9][0-9]*\).*/\1/p')
+    if [ -n "$_extracted" ]; then
+      its="$_extracted"
+    fi
+  fi
+
+  _extracted=$(echo "$annotation" | sed -n 's/.*@max_ms=\([0-9.][0-9.]*\).*/\1/p')
+  if [ -n "$_extracted" ]; then
+    max_ms="$_extracted"
+  fi
+
+  if [ -n "$max_ms" ]; then
+    echo "$revs" "$its" "$max_ms"
+  else
+    echo "$revs" "$its"
+  fi
+}
+
+function bashunit::benchmark::add_result() {
+  _BASHUNIT_BENCH_NAMES[${#_BASHUNIT_BENCH_NAMES[@]}]="$1"
+  _BASHUNIT_BENCH_REVS[${#_BASHUNIT_BENCH_REVS[@]}]="$2"
+  _BASHUNIT_BENCH_ITS[${#_BASHUNIT_BENCH_ITS[@]}]="$3"
+  _BASHUNIT_BENCH_AVERAGES[${#_BASHUNIT_BENCH_AVERAGES[@]}]="$4"
+  _BASHUNIT_BENCH_MAX_MILLIS[${#_BASHUNIT_BENCH_MAX_MILLIS[@]}]="$5"
+}
+
+# shellcheck disable=SC2155
+function bashunit::benchmark::run_function() {
+  local fn_name=$1
+  local revs=$2
+  local its=$3
+  local max_ms=$4
+  local IFS=$' \t\n'
+  local -a durations=()
+  local durations_count=0
+  local i r
+
+  for ((i = 1; i <= its; i++)); do
+    local start_time=$(bashunit::clock::now)
+    (
+      for ((r = 1; r <= revs; r++)); do
+        "$fn_name" >/dev/null 2>&1
+      done
+    )
+    local end_time=$(bashunit::clock::now)
+    local dur_ns=$(bashunit::math::calculate "($end_time - $start_time)")
+    local dur_ms=$(bashunit::math::calculate "$dur_ns / 1000000")
+    durations[durations_count]="$dur_ms"
+    durations_count=$((durations_count + 1))
+
+    if bashunit::env::is_bench_mode_enabled; then
+      local label="$(bashunit::helper::normalize_test_function_name "$fn_name")"
+      local line="$label [$i/$its] ${dur_ms} ms"
+      bashunit::state::print_line "successful" "$line"
+    fi
+  done
+
+  local sum=0
+  local d
+  for d in "${durations[@]+"${durations[@]}"}"; do
+    sum=$(bashunit::math::calculate "$sum + $d")
+  done
+  local avg=$(bashunit::math::calculate "$sum / ${#durations[@]}")
+  bashunit::benchmark::add_result "$fn_name" "$revs" "$its" "$avg" "$max_ms"
+}
+
+function bashunit::benchmark::print_results() {
+  if ! bashunit::env::is_bench_mode_enabled; then
+    return
+  fi
+
+  if ((${#_BASHUNIT_BENCH_NAMES[@]} == 0)); then
+    return
+  fi
+
+  if bashunit::env::is_simple_output_enabled; then
+    printf "\n"
+  fi
+
+  printf "\nBenchmark Results (avg ms)\n"
+  bashunit::print_line 80 "="
+  printf "\n"
+
+  local IFS=$' \t\n'
+  local has_threshold=false
+  local val
+  for val in "${_BASHUNIT_BENCH_MAX_MILLIS[@]+"${_BASHUNIT_BENCH_MAX_MILLIS[@]}"}"; do
+    if [ -n "$val" ]; then
+      has_threshold=true
+      break
+    fi
+  done
+
+  if $has_threshold; then
+    printf '%-40s %6s %6s %10s %12s\n' "Name" "Revs" "Its" "Avg(ms)" "Status"
+  else
+    printf '%-40s %6s %6s %10s\n' "Name" "Revs" "Its" "Avg(ms)"
+  fi
+
+  local i
+  for i in "${!_BASHUNIT_BENCH_NAMES[@]}"; do
+    local name="${_BASHUNIT_BENCH_NAMES[$i]:-}"
+    local revs="${_BASHUNIT_BENCH_REVS[$i]:-}"
+    local its="${_BASHUNIT_BENCH_ITS[$i]:-}"
+    local avg="${_BASHUNIT_BENCH_AVERAGES[$i]:-}"
+    local max_ms="${_BASHUNIT_BENCH_MAX_MILLIS[$i]:-}"
+
+    if [ -z "$max_ms" ]; then
+      printf '%-40s %6s %6s %10s\n' "$name" "$revs" "$its" "$avg"
+      continue
+    fi
+
+    if [ "$avg" -le "$max_ms" ]; then
+      local raw="≤ ${max_ms}"
+      local padded
+      padded=$(printf "%14s" "$raw")
+      printf '%-40s %6s %6s %10s %12s\n' "$name" "$revs" "$its" "$avg" "$padded"
+      continue
+    fi
+
+    local raw="> ${max_ms}"
+    local padded
+    padded=$(printf "%12s" "$raw")
+    printf '%-40s %6s %6s %10s %s%s%s\n' \
+      "$name" "$revs" "$its" "$avg" \
+      "$_BASHUNIT_COLOR_FAILED" "$padded" "${_BASHUNIT_COLOR_DEFAULT}"
+  done
+
+  bashunit::console_results::print_execution_time
 }
 
 # bashunit.sh
@@ -13402,6 +13134,1287 @@ function bashunit::assertion_passed() {
   bashunit::assert::should_skip && return 0
 
   bashunit::state::add_assertions_passed
+}
+
+# init.sh
+
+function bashunit::init::project() {
+  local tests_dir="${1:-$BASHUNIT_DEFAULT_PATH}"
+  mkdir -p "$tests_dir"
+
+  local bootstrap_file="$tests_dir/bootstrap.sh"
+  if [ ! -f "$bootstrap_file" ]; then
+    cat >"$bootstrap_file" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+# Place your common test setup here
+SH
+    chmod +x "$bootstrap_file"
+    echo "> Created $bootstrap_file"
+  fi
+
+  local example_test="$tests_dir/example_test.sh"
+  if [ ! -f "$example_test" ]; then
+    cat >"$example_test" <<'SH'
+#!/usr/bin/env bash
+
+function test_bashunit_is_installed() {
+  assert_same "bashunit is installed" "bashunit is installed"
+}
+SH
+    chmod +x "$example_test"
+    echo "> Created $example_test"
+  fi
+
+  local workflow_dir=".github/workflows"
+  local workflow_file="$workflow_dir/tests.yml"
+  if [ ! -f "$workflow_file" ]; then
+    mkdir -p "$workflow_dir"
+    cat >"$workflow_file" <<SH
+name: Tests
+on: [pull_request, push]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: TypedDevs/bashunit@v0
+        with:
+          args: $tests_dir
+SH
+    echo "> Created $workflow_file"
+  fi
+
+  local env_file=".env"
+  local env_line="BASHUNIT_BOOTSTRAP=$bootstrap_file"
+  if [ -f "$env_file" ]; then
+    if grep -q "^BASHUNIT_BOOTSTRAP=" "$env_file"; then
+      if bashunit::check_os::is_macos; then
+        sed -i '' -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
+      else
+        sed -i -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
+      fi
+    fi
+    echo "$env_line" >>"$env_file"
+  else
+    echo "$env_line" >"$env_file"
+  fi
+
+  echo "> bashunit initialized in $tests_dir"
+}
+
+# learn.sh
+# shellcheck disable=SC2016
+
+##
+# Interactive learning module for bashunit
+# Provides guided tutorials and exercises to learn bashunit
+##
+
+LEARN_TEMP_DIR=""
+declare -r LEARN_PROGRESS_FILE="$HOME/.bashunit_learn_progress"
+
+##
+# Initialize learning environment
+##
+function bashunit::learn::init() {
+  LEARN_TEMP_DIR=$("${MKTEMP:-mktemp}" -d "${TMPDIR:-/tmp}/bashunit_learn.XXXXXXXX")
+  mkdir -p tests
+}
+
+##
+# Cleanup learning environment
+##
+function bashunit::learn::cleanup() {
+  if [ -n "${LEARN_TEMP_DIR:-}" ] && [ -d "$LEARN_TEMP_DIR" ]; then
+    rm -rf "$LEARN_TEMP_DIR"
+  fi
+}
+
+##
+# Print the learning menu
+##
+function bashunit::learn::print_menu() {
+  cat <<EOF
+${_BASHUNIT_COLOR_BOLD}${_BASHUNIT_COLOR_PASSED}bashunit${_BASHUNIT_COLOR_DEFAULT} - Interactive Learning
+
+Choose a lesson:
+
+  ${_BASHUNIT_COLOR_BOLD}1.${_BASHUNIT_COLOR_DEFAULT} Basics - Your First Test
+  ${_BASHUNIT_COLOR_BOLD}2.${_BASHUNIT_COLOR_DEFAULT} Assertions - Testing Different Conditions
+  ${_BASHUNIT_COLOR_BOLD}3.${_BASHUNIT_COLOR_DEFAULT} Setup & Teardown - Managing Test Lifecycle
+  ${_BASHUNIT_COLOR_BOLD}4.${_BASHUNIT_COLOR_DEFAULT} Testing Functions - Unit Testing Patterns
+  ${_BASHUNIT_COLOR_BOLD}5.${_BASHUNIT_COLOR_DEFAULT} Testing Scripts - Integration Testing
+  ${_BASHUNIT_COLOR_BOLD}6.${_BASHUNIT_COLOR_DEFAULT} Mocking - Test Doubles and Mocks
+  ${_BASHUNIT_COLOR_BOLD}7.${_BASHUNIT_COLOR_DEFAULT} Spies - Verifying Function Calls
+  ${_BASHUNIT_COLOR_BOLD}8.${_BASHUNIT_COLOR_DEFAULT} Data Providers - Parameterized Tests
+  ${_BASHUNIT_COLOR_BOLD}9.${_BASHUNIT_COLOR_DEFAULT} Exit Codes - Testing Success and Failure
+  ${_BASHUNIT_COLOR_BOLD}10.${_BASHUNIT_COLOR_DEFAULT} Complete Challenge - Real World Scenario
+
+  ${_BASHUNIT_COLOR_BOLD}p.${_BASHUNIT_COLOR_DEFAULT} Show Progress
+  ${_BASHUNIT_COLOR_BOLD}r.${_BASHUNIT_COLOR_DEFAULT} Reset Progress
+  ${_BASHUNIT_COLOR_BOLD}q.${_BASHUNIT_COLOR_DEFAULT} Quit
+
+Enter your choice:
+EOF
+}
+
+##
+# Main learning loop
+##
+function bashunit::learn::start() {
+  bashunit::learn::init
+
+  trap 'bashunit::learn::cleanup' EXIT
+
+  while true; do
+    echo ""
+    bashunit::learn::print_menu
+    read -r choice
+    echo ""
+
+    case "$choice" in
+    1) bashunit::learn::lesson_basics || true ;;
+    2) bashunit::learn::lesson_assertions || true ;;
+    3) bashunit::learn::lesson_lifecycle || true ;;
+    4) bashunit::learn::lesson_functions || true ;;
+    5) bashunit::learn::lesson_scripts || true ;;
+    6) bashunit::learn::lesson_mocking || true ;;
+    7) bashunit::learn::lesson_spies || true ;;
+    8) bashunit::learn::lesson_data_providers || true ;;
+    9) bashunit::learn::lesson_exit_codes || true ;;
+    10) bashunit::learn::lesson_challenge || true ;;
+    p) bashunit::learn::show_progress ;;
+    r) bashunit::learn::reset_progress ;;
+    q)
+      echo "${_BASHUNIT_COLOR_PASSED}Happy testing!${_BASHUNIT_COLOR_DEFAULT}"
+      break
+      ;;
+    *)
+      echo "${_BASHUNIT_COLOR_FAILED}Invalid choice. Please try again.${_BASHUNIT_COLOR_DEFAULT}"
+      ;;
+    esac
+  done
+
+  bashunit::learn::cleanup
+}
+
+##
+# Mark lesson as completed
+##
+function bashunit::learn::mark_completed() {
+  local lesson=$1
+  echo "$lesson" >>"$LEARN_PROGRESS_FILE"
+}
+
+##
+# Check if lesson is completed
+##
+function bashunit::learn::is_completed() {
+  local lesson=$1
+  [ -f "$LEARN_PROGRESS_FILE" ] && [ "$("$GREP" -c "^$lesson$" "$LEARN_PROGRESS_FILE" || true)" -gt 0 ]
+}
+
+##
+# Show learning progress
+##
+function bashunit::learn::show_progress() {
+  if [ ! -f "$LEARN_PROGRESS_FILE" ]; then
+    echo "${_BASHUNIT_COLOR_INCOMPLETE}No progress yet. Start with lesson 1!${_BASHUNIT_COLOR_DEFAULT}"
+    return
+  fi
+
+  echo "${_BASHUNIT_COLOR_BOLD}Your Progress:${_BASHUNIT_COLOR_DEFAULT}"
+  echo ""
+
+  local total_lessons=10
+  local completed=0
+
+  local i
+  for i in $(seq 1 $total_lessons); do
+    if bashunit::learn::is_completed "lesson_$i"; then
+      echo "  ${_BASHUNIT_COLOR_PASSED}✓${_BASHUNIT_COLOR_DEFAULT} Lesson $i completed"
+      ((++completed)) || true
+    else
+      echo "  ${_BASHUNIT_COLOR_INCOMPLETE}○${_BASHUNIT_COLOR_DEFAULT} Lesson $i"
+    fi
+  done
+
+  echo ""
+  echo "Progress: $completed/$total_lessons lessons completed"
+
+  if [ $completed -eq $total_lessons ]; then
+    echo ""
+    printf "%s%s🎉 Congratulations! You've completed all lessons!%s\n" \
+      "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_BOLD" "$_BASHUNIT_COLOR_DEFAULT"
+  fi
+
+  read -p "Press Enter to continue..." -r
+}
+
+##
+# Reset learning progress
+##
+function bashunit::learn::reset_progress() {
+  rm -f "$LEARN_PROGRESS_FILE"
+  echo "${_BASHUNIT_COLOR_PASSED}Progress reset successfully.${_BASHUNIT_COLOR_DEFAULT}"
+  read -p "Press Enter to continue..." -r
+}
+
+##
+# Create the example file automatically
+# Arguments: $1 - filename, $2 - file content
+##
+function bashunit::learn::create_example_file() {
+  local filename=$1
+  local content=$2
+
+  echo ""
+  echo "Creating example file ${_BASHUNIT_COLOR_BOLD}$filename${_BASHUNIT_COLOR_DEFAULT}..."
+  echo "$content" >"$filename"
+  chmod +x "$filename"
+  echo "${_BASHUNIT_COLOR_PASSED}✓ Created $filename${_BASHUNIT_COLOR_DEFAULT}"
+  echo ""
+  echo "File created! Edit it to complete the TODO items, then run this lesson again."
+  read -p "Press Enter to continue..." -r
+  return 0
+}
+
+##
+# Run a lesson test and check results
+##
+function bashunit::learn::run_lesson_test() {
+  local test_file=$1
+  local lesson_number=$2
+
+  echo "${_BASHUNIT_COLOR_BOLD}Running your test...${_BASHUNIT_COLOR_DEFAULT}"
+  echo ""
+
+  if "$BASHUNIT_ROOT_DIR/bashunit" "$test_file" --simple; then
+    echo ""
+    printf "%s%s✓ Excellent! Lesson %s completed!%s\n" \
+      "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_BOLD" "$lesson_number" "$_BASHUNIT_COLOR_DEFAULT"
+    bashunit::learn::mark_completed "lesson_$lesson_number"
+    read -p "Press Enter to continue..." -r
+    return 0
+  else
+    echo ""
+    echo "${_BASHUNIT_COLOR_FAILED}Not quite right. Review the requirements and try again.${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+}
+
+##
+# Lesson 1: Basics - Your First Test
+##
+function bashunit::learn::lesson_basics() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║                    Lesson 1: Your First Test                   ║
+╚════════════════════════════════════════════════════════════════╝
+
+Welcome to bashunit! Let's write your first test.
+
+CONCEPT: A test is a function that starts with 'test_' and uses
+assertions to verify behavior.
+
+TASK: Create a test file that checks if two values are equal.
+
+File: tests/first_test.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function test_bashunit_works() {
+  # TODO: Use assert_same to check if "hello" equals "hello"
+  # Hint: assert_same "expected" "actual"
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • The assert_same function takes two arguments:
+    assert_same "expected" "actual"
+  • Test functions must start with "test_" prefix
+  • Always quote your strings to avoid word splitting
+  • Keep test files in a tests/ directory for better organization
+EOF
+
+  local default_file="tests/first_test.sh"
+  echo ""
+  printf "When ready, enter file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function test_bashunit_works() {
+  # TODO: Use assert_same to check if "hello" equals "hello"
+  # Hint: assert_same "expected" "actual"
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  # Check if file contains assert_same
+  if [ "$("$GREP" -c "assert_same" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should use assert_same${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 1
+}
+
+##
+# Lesson 2: Assertions - Testing Different Conditions
+##
+function bashunit::learn::lesson_assertions() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║              Lesson 2: Testing Different Conditions            ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: bashunit provides many assertion functions for different checks:
+  • assert_same - exact equality
+  • assert_contains - substring check
+  • assert_matches - regex pattern
+  • assert_not_same - inequality
+  • assert_empty - checks if value is empty
+  • assert_not_empty - checks if value is not empty
+
+TASK: Write a test file with 3 different assertions.
+
+File: tests/assertions_test.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function test_multiple_assertions() {
+  local message="Hello, bashunit!"
+
+  # TODO: Check that message contains "bashunit"
+  # Hint: assert_contains "substring" "$message"
+
+  # TODO: Check that message matches the pattern "Hello.*!"
+  # Hint: assert_matches "pattern" "$message"
+
+  # TODO: Check that message is not empty
+  # Hint: assert_not_empty "$message"
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • assert_same checks exact equality (useful for strings/numbers)
+  • assert_contains is more flexible for partial matches
+  • assert_matches uses regex patterns (e.g., "^[0-9]+$" for numbers)
+  • Explore more: assert_empty, assert_true, assert_false
+EOF
+
+  local default_file="tests/assertions_test.sh"
+  echo ""
+  printf "When ready, enter file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function test_multiple_assertions() {
+  local message="Hello, bashunit!"
+
+  # TODO: Check that message contains "bashunit"
+  # Hint: assert_contains "substring" "$message"
+
+  # TODO: Check that message matches the pattern "Hello.*!"
+  # Hint: assert_matches "pattern" "$message"
+
+  # TODO: Check that message is not empty
+  # Hint: assert_not_empty "$message"
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  if [ "$("$GREP" -c "assert_contains" "$test_file" || true)" -eq 0 ] ||
+    [ "$("$GREP" -c "assert_matches" "$test_file" || true)" -eq 0 ] ||
+    [ "$("$GREP" -c "assert_not_empty" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should use all three assertion types${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 2
+}
+
+##
+# Lesson 3: Setup & Teardown - Managing Test Lifecycle
+##
+function bashunit::learn::lesson_lifecycle() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║           Lesson 3: Setup and Teardown Functions               ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: Tests often need preparation and cleanup. bashunit provides:
+  • set_up() - runs before EACH test
+  • tear_down() - runs after EACH test
+  • set_up_before_script() - runs once before ALL tests
+  • tear_down_after_script() - runs once after ALL tests
+
+TASK: Create a test that uses setup and teardown to manage files.
+
+File: tests/lifecycle_test.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function set_up() {
+  # Create a temp file before each test
+  # TODO: export TEST_FILE="/tmp/test_$$"
+  # TODO: echo "test content" > "$TEST_FILE"
+}
+
+function tear_down() {
+  # Clean up after each test
+  # TODO: rm -f "$TEST_FILE"
+}
+
+function test_file_exists() {
+  # TODO: assert_file_exists "$TEST_FILE"
+}
+
+function test_file_has_content() {
+  # TODO: assert_file_contains "test content" "$TEST_FILE"
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • set_up() runs before EACH test (good for test isolation)
+  • set_up_before_script() runs ONCE before all tests (good for expensive setup)
+  • Always clean up in tear_down() to avoid polluting other tests
+  • Use $$ for unique temp file names to avoid conflicts
+EOF
+
+  local default_file="tests/lifecycle_test.sh"
+  echo ""
+  printf "When ready, enter file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function set_up() {
+  # Create a temp file before each test
+  # TODO: export TEST_FILE="/tmp/test_$$"
+  # TODO: echo "test content" > "$TEST_FILE"
+}
+
+function tear_down() {
+  # Clean up after each test
+  # TODO: rm -f "$TEST_FILE"
+}
+
+function test_file_exists() {
+  # TODO: assert_file_exists "$TEST_FILE"
+}
+
+function test_file_has_content() {
+  # TODO: assert_file_contains "test content" "$TEST_FILE"
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  if [ "$("$GREP" -c "function set_up()" "$test_file" || true)" -eq 0 ] ||
+    [ "$("$GREP" -c "function tear_down()" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should define set_up and tear_down functions${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 3
+}
+
+##
+# Lesson 4: Testing Functions
+##
+function bashunit::learn::lesson_functions() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║              Lesson 4: Testing Bash Functions                  ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: To test functions, source the file containing them, then
+call them in your tests.
+
+TASK: Create a script with a function, then test it.
+
+File: calculator.sh (source code)
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function add() {
+  echo $(($1 + $2))
+}
+───────────────────────────────────────────────────────────────
+
+File: tests/calculator_test.sh (test file)
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function set_up() {
+  # TODO: Source calculator.sh from parent directory
+  # Hint: source ../calculator.sh
+}
+
+function test_add_positive_numbers() {
+  # TODO: Test that add 2 3 returns "5"
+  # Hint: result=$(add 2 3)
+  # Hint: assert_same "5" "$result"
+}
+
+function test_add_negative_numbers() {
+  # TODO: Test that add -2 -3 returns "-5"
+  # Hint: result=$(add -2 -3)
+  # Hint: assert_same "-5" "$result"
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • Source files in set_up() to reload them fresh for each test
+  • Capture function output with: result=$(function_name args)
+  • Test edge cases: positive, negative, zero, large numbers
+  • Source files from parent directory: source ../file.sh
+EOF
+
+  local default_file="tests/calculator_test.sh"
+  echo ""
+  printf "When ready, enter TEST file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function set_up() {
+  # TODO: Source calculator.sh from parent directory
+  # Hint: source ../calculator.sh
+}
+
+function test_add_positive_numbers() {
+  # TODO: Test that add 2 3 returns "5"
+  # Hint: result=$(add 2 3)
+  # Hint: assert_same "5" "$result"
+}
+
+function test_add_negative_numbers() {
+  # TODO: Test that add -2 -3 returns "-5"
+  # Hint: result=$(add -2 -3)
+  # Hint: assert_same "-5" "$result"
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  if [ "$("$GREP" -c "source" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should source the calculator.sh file${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 4
+}
+
+##
+# Lesson 5: Testing Scripts
+##
+function bashunit::learn::lesson_scripts() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║                 Lesson 5: Testing Bash Scripts                 ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: Scripts that execute commands directly are tested differently.
+Run them and capture their output.
+
+TASK: Create a script and test its output.
+
+File: greeter.sh (source code)
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+name=${1:-World}
+echo "Hello, $name!"
+───────────────────────────────────────────────────────────────
+
+File: tests/greeter_test.sh (test file)
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function test_default_greeting() {
+  # TODO: Run greeter.sh from parent directory and capture output
+  # Hint: output=$(../greeter.sh)
+
+  # TODO: Assert output contains "Hello, World!"
+  # Hint: assert_contains "Hello, World!" "$output"
+}
+
+function test_custom_greeting() {
+  # TODO: Run greeter.sh with argument "Alice"
+  # Hint: output=$(../greeter.sh "Alice")
+
+  # TODO: Assert output contains "Hello, Alice!"
+  # Hint: assert_contains "Hello, Alice!" "$output"
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • Use command substitution: output=$(./script.sh)
+  • Make scripts executable: chmod +x script.sh
+  • Test both default behavior and with various arguments
+  • Scripts run in subshells, so they can't modify parent environment
+  • Run scripts from parent directory: ../script.sh
+EOF
+
+  local default_file="tests/greeter_test.sh"
+  echo ""
+  printf "When ready, enter TEST file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function test_default_greeting() {
+  # TODO: Run greeter.sh from parent directory and capture output
+  # Hint: output=$(../greeter.sh)
+
+  # TODO: Assert output contains "Hello, World!"
+  # Hint: assert_contains "Hello, World!" "$output"
+}
+
+function test_custom_greeting() {
+  # TODO: Run greeter.sh with argument "Alice"
+  # Hint: output=$(../greeter.sh "Alice")
+
+  # TODO: Assert output contains "Hello, Alice!"
+  # Hint: assert_contains "Hello, Alice!" "$output"
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 5
+}
+
+##
+# Lesson 6: Mocking
+##
+function bashunit::learn::lesson_mocking() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║               Lesson 6: Mocking External Commands              ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: Mocks let you override external commands or functions to
+control their behavior in tests.
+
+TASK: Test a function that uses external commands.
+
+File: system_info.sh (source code)
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function get_system_info() {
+  echo "OS: $(uname -s)"
+}
+───────────────────────────────────────────────────────────────
+
+File: tests/system_info_test.sh (test file)
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function set_up() {
+  source ../system_info.sh
+}
+
+function test_system_info_on_linux() {
+  # TODO: Mock uname to return "Linux"
+  # Hint: mock uname echo "Linux"
+
+  local output
+  output=$(get_system_info)
+
+  # TODO: Assert output contains "OS: Linux"
+}
+
+function test_system_info_on_macos() {
+  # TODO: Mock uname to return "Darwin"
+
+  local output
+  output=$(get_system_info)
+
+  # TODO: Assert output contains "OS: Darwin"
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • Mocks replace commands/functions with custom behavior
+  • Syntax: mock command_name echo "mocked output"
+  • Mocks are automatically cleaned up after each test
+  • Use mocks to avoid calling expensive external commands
+EOF
+
+  local default_file="tests/system_info_test.sh"
+  echo ""
+  printf "When ready, enter TEST file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function set_up() {
+  source ../system_info.sh
+}
+
+function test_system_info_on_linux() {
+  # TODO: Mock uname to return "Linux"
+  # Hint: mock uname echo "Linux"
+
+  local output
+  output=$(get_system_info)
+
+  # TODO: Assert output contains "OS: Linux"
+}
+
+function test_system_info_on_macos() {
+  # TODO: Mock uname to return "Darwin"
+
+  local output
+  output=$(get_system_info)
+
+  # TODO: Assert output contains "OS: Darwin"
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  if [ "$("$GREP" -c "mock" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should use mock${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 6
+}
+
+##
+# Lesson 7: Spies
+##
+function bashunit::learn::lesson_spies() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║              Lesson 7: Spies - Verifying Calls                 ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: Spies let you verify that functions were called with specific
+arguments or a certain number of times.
+
+KEY DIFFERENCE: Spies track calls without changing behavior, while
+mocks (Lesson 6) replace the function entirely with custom behavior.
+
+TASK: Use spies to verify function calls.
+
+File: deploy.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function deploy_app() {
+  git push origin main
+  docker build -t myapp .
+  docker push myapp
+}
+───────────────────────────────────────────────────────────────
+
+File: deploy_test.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function set_up() {
+  source deploy.sh
+}
+
+function test_deploy_calls_git_push() {
+  # TODO: Create spies for git and docker
+  # Hint: spy git
+  # Hint: spy docker
+
+  deploy_app
+
+  # TODO: Assert git was called
+  # Hint: assert_have_been_called git
+
+  # TODO: Assert docker was called
+}
+
+function test_deploy_calls_docker_twice() {
+  # TODO: Spy on docker
+
+  deploy_app
+
+  # TODO: Assert docker was called exactly 2 times
+  # Hint: assert_have_been_called_times 2 docker
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • Spies track calls but don't change behavior (unlike mocks)
+  • assert_have_been_called - verifies at least one call
+  • assert_have_been_called_times N - verifies exact call count
+  • assert_have_been_called_with - verifies specific arguments
+  • Spies are cleaned up automatically after each test
+EOF
+
+  local default_file="deploy_test.sh"
+  echo ""
+  printf "When ready, enter TEST file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function set_up() {
+  source deploy.sh
+}
+
+function test_deploy_calls_git_push() {
+  # TODO: Create spies for git and docker
+  # Hint: spy git
+  # Hint: spy docker
+
+  deploy_app
+
+  # TODO: Assert git was called
+  # Hint: assert_have_been_called git
+
+  # TODO: Assert docker was called
+}
+
+function test_deploy_calls_docker_twice() {
+  # TODO: Spy on docker
+
+  deploy_app
+
+  # TODO: Assert docker was called exactly 2 times
+  # Hint: assert_have_been_called_times 2 docker
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  if [ "$("$GREP" -c "spy" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should use spy${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 7
+}
+
+##
+# Lesson 8: Data Providers
+##
+function bashunit::learn::lesson_data_providers() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║           Lesson 8: Data Providers - Parameterized Tests       ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: Data providers let you run the same test with different inputs.
+Define a function that echoes test data, one per line.
+
+HOW IT WORKS: Each line from data_provider_* becomes $1 in your test.
+The test runs once for each line of data.
+
+TASK: Test multiple email formats using a data provider.
+
+File: validator.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function is_valid_email() {
+  local email_pattern='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+  [ "$(echo "$1" | "$GREP" -cE "$email_pattern" || true)" -gt 0 ]
+}
+───────────────────────────────────────────────────────────────
+
+File: validator_test.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function set_up() {
+  source validator.sh
+}
+
+function data_provider_valid_emails() {
+  # TODO: Echo valid email addresses, one per line
+  # Example: echo "user@example.com"
+}
+
+function test_valid_emails() {
+  # $1 contains the email from data provider
+  # TODO: Assert is_valid_email succeeds
+  # Hint: assert_successful_code "is_valid_email \"$1\""
+}
+
+function data_provider_invalid_emails() {
+  # TODO: Echo invalid email addresses, one per line
+  # Example: echo "not-an-email"
+}
+
+function test_invalid_emails() {
+  # TODO: Assert is_valid_email fails
+  # Hint: assert_general_error "is_valid_email \"$1\""
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • Data providers must be named: data_provider_<test_name>
+  • Each line of output becomes one test case
+  • The test function receives the line as $1
+  • Great for testing multiple inputs without duplicating code
+  • You can have multiple data provider/test pairs in one file
+EOF
+
+  local default_file="validator_test.sh"
+  echo ""
+  printf "When ready, enter TEST file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function set_up() {
+  source validator.sh
+}
+
+function data_provider_valid_emails() {
+  # TODO: Echo valid email addresses, one per line
+  # Example: echo "user@example.com"
+}
+
+function test_valid_emails() {
+  # $1 contains the email from data provider
+  # TODO: Assert is_valid_email succeeds
+  # Hint: assert_successful_code "is_valid_email \"$1\""
+}
+
+function data_provider_invalid_emails() {
+  # TODO: Echo invalid email addresses, one per line
+  # Example: echo "not-an-email"
+}
+
+function test_invalid_emails() {
+  # TODO: Assert is_valid_email fails
+  # Hint: assert_general_error "is_valid_email \"$1\""
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  if [ "$("$GREP" -c "function data_provider_" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should define data provider functions${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 8
+}
+
+##
+# Lesson 9: Exit Codes
+##
+function bashunit::learn::lesson_exit_codes() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║             Lesson 9: Testing Exit Codes                       ║
+╚════════════════════════════════════════════════════════════════╝
+
+CONCEPT: Exit codes indicate success (0) or failure (non-zero).
+bashunit provides assertions to test them:
+  • assert_successful_code - expects exit code 0
+  • assert_general_error - expects exit code 1
+  • assert_exit_code N - expects specific exit code N
+
+TASK: Test different exit codes.
+
+File: checker.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function check_file() {
+  if [ ! -e "$1" ]; then
+    echo "File not found" >&2
+    return 127
+  fi
+
+  if [ ! -r "$1" ]; then
+    echo "Permission denied" >&2
+    return 1
+  fi
+
+  echo "File OK"
+  return 0
+}
+───────────────────────────────────────────────────────────────
+
+File: checker_test.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function set_up() {
+  source checker.sh
+  # Create a test file
+  export TEST_FILE="/tmp/test_file_$$"
+  touch "$TEST_FILE"
+}
+
+function tear_down() {
+  rm -f "$TEST_FILE"
+}
+
+function test_existing_file_returns_success() {
+  # TODO: Assert check_file succeeds with TEST_FILE
+  # Hint: assert_successful_code "check_file '$TEST_FILE'"
+}
+
+function test_missing_file_returns_127() {
+  # TODO: Assert check_file returns exit code 127 for missing file
+  # Hint: assert_exit_code 127 "check_file '/nonexistent/file'"
+}
+───────────────────────────────────────────────────────────────
+
+TIPS:
+  • Exit code 0 = success (assert_successful_code)
+  • Exit code 1 = general error (assert_general_error)
+  • Other codes = specific errors (assert_exit_code N)
+  • Bash uses 'return N' in functions, 'exit N' in scripts
+  • Common codes: 127=not found, 126=not executable, 2=misuse
+EOF
+
+  local default_file="checker_test.sh"
+  echo ""
+  printf "When ready, enter TEST file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function set_up() {
+  source checker.sh
+  # Create a test file
+  export TEST_FILE="/tmp/test_file_$$"
+  touch "$TEST_FILE"
+}
+
+function tear_down() {
+  rm -f "$TEST_FILE"
+}
+
+function test_existing_file_returns_success() {
+  # TODO: Assert check_file succeeds with TEST_FILE
+  # Hint: assert_successful_code "check_file '\''$TEST_FILE'\''"
+}
+
+function test_missing_file_returns_127() {
+  # TODO: Assert check_file returns exit code 127 for missing file
+  # Hint: assert_exit_code 127 "check_file '\''/nonexistent/file'\''"
+}'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  local _exit_assert_pattern="assert_successful_code\|assert_exit_code\|assert_general_error"
+  if [ "$("$GREP" -c "$_exit_assert_pattern" "$test_file" || true)" -eq 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Your test should use exit code assertions${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  bashunit::learn::run_lesson_test "$test_file" 9
+}
+
+##
+# Lesson 10: Complete Challenge
+##
+function bashunit::learn::lesson_challenge() {
+  clear
+  cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║          Lesson 10: Complete Challenge - Backup Script         ║
+╚════════════════════════════════════════════════════════════════╝
+
+FINAL CHALLENGE: Combine everything you've learned!
+
+CONCEPT: Real-world tests combine multiple concepts: lifecycle
+management, assertions, exit codes, and test doubles.
+
+TASK: Create a backup script and comprehensive tests.
+
+File: backup.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+function create_backup() {
+  local source=$1
+  local dest=$2
+
+  if [ ! -d "$source" ]; then
+    echo "Source directory not found" >&2
+    return 1
+  fi
+
+  tar -czf "$dest" -C "$source" .
+  echo "Backup created: $dest"
+}
+───────────────────────────────────────────────────────────────
+
+File: backup_test.sh
+───────────────────────────────────────────────────────────────
+#!/usr/bin/env bash
+
+Your test must include:
+  1. set_up and tear_down functions
+  2. Test successful backup creation
+  3. Test failure when source doesn't exist
+  4. Mock or spy on tar command
+  5. Verify backup file exists
+  6. Check output message
+
+TIP: Combine patterns from all previous lessons!
+EOF
+
+  local default_file="backup_test.sh"
+  echo ""
+  printf "When ready, enter TEST file path %s[%s]%s: " \
+    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
+  read -r test_file
+  test_file="${test_file:-$default_file}"
+
+  if [ ! -f "$test_file" ]; then
+    local template='#!/usr/bin/env bash
+
+function set_up() {
+  source backup.sh
+  # TODO: Create test directories and variables
+}
+
+function tear_down() {
+  # TODO: Clean up test files
+}
+
+function test_successful_backup() {
+  # TODO: Test backup creation
+}
+
+function test_backup_failure_when_source_missing() {
+  # TODO: Test failure case
+}
+
+# Add more tests as needed:
+# - Mock or spy on tar command
+# - Verify backup file exists
+# - Check output message
+#
+# TIPS:
+# - Combine lifecycle (set_up/tear_down) with file assertions
+# - Use spies to verify tar was called correctly
+# - Test both success and failure scenarios
+# - Mock external commands to avoid side effects'
+
+    bashunit::learn::create_example_file "$test_file" "$template"
+    return 1
+  fi
+
+  # Verify the test has key components
+  local -a missing_components=()
+  local missing_components_count=0
+
+  if [ "$("$GREP" -c "function set_up()" "$test_file" || true)" -eq 0 ]; then
+    missing_components[missing_components_count]="set_up function"
+    missing_components_count=$((missing_components_count + 1))
+  fi
+
+  if [ "$("$GREP" -c "function tear_down()" "$test_file" || true)" -eq 0 ]; then
+    missing_components[missing_components_count]="tear_down function"
+    missing_components_count=$((missing_components_count + 1))
+  fi
+
+  if [ "$missing_components_count" -gt 0 ]; then
+    echo "${_BASHUNIT_COLOR_FAILED}Missing required components:${_BASHUNIT_COLOR_DEFAULT}"
+    printf "  - %s\n" "${missing_components[@]}"
+    read -p "Press Enter to continue..." -r
+    return 1
+  fi
+
+  if bashunit::learn::run_lesson_test "$test_file" 10; then
+    echo ""
+    echo "${_BASHUNIT_COLOR_PASSED}${_BASHUNIT_COLOR_BOLD}"
+    cat <<'EOF'
+╔════════════════════════════════════════════════════════════════╗
+║                   🎉 CONGRATULATIONS! 🎉                       ║
+║                                                                ║
+║          You've completed all bashunit lessons!                ║
+║                                                                ║
+║  You now know how to:                                          ║
+║    ✓ Write and run tests                                       ║
+║    ✓ Use various assertions                                    ║
+║    ✓ Manage test lifecycle                                     ║
+║    ✓ Test functions and scripts                                ║
+║    ✓ Mock external dependencies                                ║
+║    ✓ Spy on function calls                                     ║
+║    ✓ Use data providers                                        ║
+║    ✓ Test exit codes                                           ║
+║                                                                ║
+║  Next steps:                                                   ║
+║    • Explore https://bashunit.com                              ║
+║    • Check out /common-patterns for more examples              ║
+║    • Start testing your own bash scripts!                      ║
+╚════════════════════════════════════════════════════════════════╝
+EOF
+    echo "${_BASHUNIT_COLOR_DEFAULT}"
+    read -p "Press Enter to continue..." -r
+  fi
 }
 
 # main.sh
@@ -13433,8 +14446,10 @@ function bashunit::main::set_shard_or_exit() {
     exit 1
   fi
 
-  export BASHUNIT_SHARD_INDEX="$index"
-  export BASHUNIT_SHARD_TOTAL="$total"
+  BASHUNIT_SHARD_INDEX="$index"
+  export -n BASHUNIT_SHARD_INDEX
+  BASHUNIT_SHARD_TOTAL="$total"
+  export -n BASHUNIT_SHARD_TOTAL
 }
 
 #############################
@@ -13452,7 +14467,18 @@ function bashunit::main::cmd_test() {
   local assert_fn=""
   local _bashunit_coverage_opt_set=false
 
-  # Parse test-specific options
+  # Parse test-specific options.
+  #
+  # Flag branches assign WITHOUT export and strip the export attribute with
+  # `export -n`: run-mode flags are this-process-only. Everything that reads
+  # them (runner, reporters, parallel workers) runs in this shell or its
+  # subshells, which inherit unexported variables — while exec'd children
+  # (nested bashunit runs: bashunit's own acceptance suite under
+  # `build.sh --verify`, or a user's script under test that calls bashunit)
+  # must NOT inherit the parent's flags (#834, #837). The explicit `export -n`
+  # also clears an export attribute stamped by an allexport .env load.
+  # Pair any newly exported-by-necessity flag with a comment naming the exec'd
+  # consumer, and extend tests/acceptance/fixtures/flag_env_leak/leak_probe.sh.
   while [ $# -gt 0 ]; do
     case "$1" in
     -a | --assert)
@@ -13480,13 +14506,16 @@ function bashunit::main::cmd_test() {
       shift
       ;;
     -s | --simple)
-      export BASHUNIT_SIMPLE_OUTPUT=true
+      BASHUNIT_SIMPLE_OUTPUT=true
+      export -n BASHUNIT_SIMPLE_OUTPUT
       ;;
     --detailed)
-      export BASHUNIT_SIMPLE_OUTPUT=false
+      BASHUNIT_SIMPLE_OUTPUT=false
+      export -n BASHUNIT_SIMPLE_OUTPUT
       ;;
     --output)
-      export BASHUNIT_OUTPUT_FORMAT="$2"
+      BASHUNIT_OUTPUT_FORMAT="$2"
+      export -n BASHUNIT_OUTPUT_FORMAT
       shift
       ;;
     --debug)
@@ -13498,47 +14527,74 @@ function bashunit::main::cmd_test() {
       set -x
       ;;
     -S | --stop-on-failure)
-      export BASHUNIT_STOP_ON_FAILURE=true
+      # This-process-only: parallel stop uses a flag file and sync stop uses
+      # exit codes, so no child process needs it — exported (including via an
+      # allexport .env load, hence export -n) it leaked into nested bashunit
+      # runs, aborting them before rerun::persist could write
+      # .bashunit/last-failed (broke verify's acceptance tests, #834).
+      BASHUNIT_STOP_ON_FAILURE=true
+      export -n BASHUNIT_STOP_ON_FAILURE
       ;;
     -p | --parallel)
-      export BASHUNIT_PARALLEL_RUN=true
+      BASHUNIT_PARALLEL_RUN=true
+      export -n BASHUNIT_PARALLEL_RUN
       ;;
     -j | --jobs)
-      export BASHUNIT_PARALLEL_RUN=true
-      export BASHUNIT_PARALLEL_JOBS="$2"
+      BASHUNIT_PARALLEL_RUN=true
+      export -n BASHUNIT_PARALLEL_RUN
+      # "auto" caps at the detected core count; wait_for_job_slot needs an
+      # integer, so resolve it here rather than leaking the string downstream.
+      if [ "$2" = "auto" ]; then
+        BASHUNIT_PARALLEL_JOBS="$(bashunit::check_os::nproc)"
+        export -n BASHUNIT_PARALLEL_JOBS
+      else
+        BASHUNIT_PARALLEL_JOBS="$2"
+        export -n BASHUNIT_PARALLEL_JOBS
+      fi
       shift
       ;;
     --no-parallel)
-      export BASHUNIT_PARALLEL_RUN=false
+      BASHUNIT_PARALLEL_RUN=false
+      export -n BASHUNIT_PARALLEL_RUN
       ;;
     --test-timeout)
-      export BASHUNIT_TEST_TIMEOUT="$2"
+      BASHUNIT_TEST_TIMEOUT="$2"
+      export -n BASHUNIT_TEST_TIMEOUT
       shift
       ;;
     --retry)
-      export BASHUNIT_RETRY="$2"
+      BASHUNIT_RETRY="$2"
+      export -n BASHUNIT_RETRY
       shift
       ;;
     --random-order)
-      export BASHUNIT_RANDOM_ORDER=true
+      BASHUNIT_RANDOM_ORDER=true
+      export -n BASHUNIT_RANDOM_ORDER
       ;;
     --seed)
-      export BASHUNIT_SEED="$2"
+      BASHUNIT_SEED="$2"
+      export -n BASHUNIT_SEED
       shift
       ;;
     --shard)
       bashunit::main::set_shard_or_exit "$2"
       shift
       ;;
+    --rerun-failed)
+      BASHUNIT_RERUN_FAILED=true
+      export -n BASHUNIT_RERUN_FAILED
+      ;;
     -w | --watch)
-      export BASHUNIT_WATCH_MODE=true
+      BASHUNIT_WATCH_MODE=true
+      export -n BASHUNIT_WATCH_MODE
       ;;
     -e | --env | --boot)
       # Support: --env "bootstrap.sh arg1 arg2"
       local boot_file="${2%% *}"
       local boot_args="${2#* }"
       if [ "$boot_args" != "$2" ]; then
-        export BASHUNIT_BOOTSTRAP_ARGS="$boot_args"
+        BASHUNIT_BOOTSTRAP_ARGS="$boot_args"
+        export -n BASHUNIT_BOOTSTRAP_ARGS
       fi
       # Export all variables from the env file so they're available in subshells
       # (e.g., process substitution used in load_test_files)
@@ -13548,71 +14604,96 @@ function bashunit::main::cmd_test() {
       set +o allexport
       shift
       ;;
+    # Report flags are this-process-only: reports are generated by the main
+    # shell after aggregation, no child process reads these. `export -n` also
+    # strips an export attribute inherited from an allexport .env load —
+    # otherwise nested bashunit runs (bashunit's own acceptance tests, or a
+    # user's scripts under test that call bashunit) silently write their own
+    # reports over the parent's files and blow the per-run fork budget (#834).
     --log-junit | --report-junit)
-      export BASHUNIT_LOG_JUNIT="$2"
+      BASHUNIT_LOG_JUNIT="$2"
+      export -n BASHUNIT_LOG_JUNIT
       shift
       ;;
     --log-gha)
-      export BASHUNIT_LOG_GHA="$2"
+      BASHUNIT_LOG_GHA="$2"
+      export -n BASHUNIT_LOG_GHA
       shift
       ;;
     -r | --report-html)
-      export BASHUNIT_REPORT_HTML="$2"
+      BASHUNIT_REPORT_HTML="$2"
+      export -n BASHUNIT_REPORT_HTML
       shift
       ;;
     --report-tap)
-      export BASHUNIT_REPORT_TAP="$2"
+      BASHUNIT_REPORT_TAP="$2"
+      export -n BASHUNIT_REPORT_TAP
       shift
       ;;
     --report-json)
-      export BASHUNIT_REPORT_JSON="$2"
+      BASHUNIT_REPORT_JSON="$2"
+      export -n BASHUNIT_REPORT_JSON
       shift
       ;;
     --no-output)
-      export BASHUNIT_NO_OUTPUT=true
+      BASHUNIT_NO_OUTPUT=true
+      export -n BASHUNIT_NO_OUTPUT
       ;;
     -vvv | --verbose)
-      export BASHUNIT_VERBOSE=true
+      BASHUNIT_VERBOSE=true
+      export -n BASHUNIT_VERBOSE
       ;;
     -h | --help)
       bashunit::console_header::print_test_help
       exit 0
       ;;
     --show-skipped)
-      export BASHUNIT_SHOW_SKIPPED=true
+      BASHUNIT_SHOW_SKIPPED=true
+      export -n BASHUNIT_SHOW_SKIPPED
       ;;
     --show-incomplete)
-      export BASHUNIT_SHOW_INCOMPLETE=true
+      BASHUNIT_SHOW_INCOMPLETE=true
+      export -n BASHUNIT_SHOW_INCOMPLETE
       ;;
     --failures-only)
-      export BASHUNIT_FAILURES_ONLY=true
+      BASHUNIT_FAILURES_ONLY=true
+      export -n BASHUNIT_FAILURES_ONLY
       ;;
     --fail-on-risky)
-      export BASHUNIT_FAIL_ON_RISKY=true
+      BASHUNIT_FAIL_ON_RISKY=true
+      export -n BASHUNIT_FAIL_ON_RISKY
       ;;
     --profile)
-      export BASHUNIT_PROFILE=true
+      BASHUNIT_PROFILE=true
+      export -n BASHUNIT_PROFILE
       ;;
     --show-output)
-      export BASHUNIT_SHOW_OUTPUT_ON_FAILURE=true
+      BASHUNIT_SHOW_OUTPUT_ON_FAILURE=true
+      export -n BASHUNIT_SHOW_OUTPUT_ON_FAILURE
       ;;
     --no-output-on-failure)
-      export BASHUNIT_SHOW_OUTPUT_ON_FAILURE=false
+      BASHUNIT_SHOW_OUTPUT_ON_FAILURE=false
+      export -n BASHUNIT_SHOW_OUTPUT_ON_FAILURE
       ;;
     --no-progress)
-      export BASHUNIT_NO_PROGRESS=true
+      BASHUNIT_NO_PROGRESS=true
+      export -n BASHUNIT_NO_PROGRESS
       ;;
     --strict)
-      export BASHUNIT_STRICT_MODE=true
+      BASHUNIT_STRICT_MODE=true
+      export -n BASHUNIT_STRICT_MODE
       ;;
     -R | --run-all)
-      export BASHUNIT_STOP_ON_ASSERTION_FAILURE=false
+      BASHUNIT_STOP_ON_ASSERTION_FAILURE=false
+      export -n BASHUNIT_STOP_ON_ASSERTION_FAILURE
       ;;
     --skip-env-file)
-      export BASHUNIT_SKIP_ENV_FILE=true
+      BASHUNIT_SKIP_ENV_FILE=true
+      export -n BASHUNIT_SKIP_ENV_FILE
       ;;
     -l | --login)
-      export BASHUNIT_LOGIN_SHELL=true
+      BASHUNIT_LOGIN_SHELL=true
+      export -n BASHUNIT_LOGIN_SHELL
       ;;
     --no-color)
       # shellcheck disable=SC2034
@@ -13740,6 +14821,30 @@ function bashunit::main::cmd_test() {
     fi
   fi
 
+  # --rerun-failed: restrict discovery to the files recorded as failing last
+  # run. Function-level filtering happens in the runner; --filter/--tag still
+  # apply on top. With no recorded failures, fall back to the full suite.
+  if [ -z "$assert_fn" ] && bashunit::rerun::is_enabled; then
+    bashunit::rerun::load
+    if bashunit::rerun::has_entries; then
+      local -a _rerun_files=()
+      local _rerun_file
+      while IFS= read -r _rerun_file; do
+        [ -z "$_rerun_file" ] && continue
+        # Skip entries pointing at deleted files, don't crash.
+        [ -f "$_rerun_file" ] || continue
+        _rerun_files[${#_rerun_files[@]}]="$_rerun_file"
+      done < <(bashunit::rerun::files)
+      if [ "${#_rerun_files[@]}" -gt 0 ]; then
+        args=("${_rerun_files[@]}")
+        args_count=${#args[@]}
+      fi
+    else
+      printf "%sNo previously failing tests recorded; running the full suite.%s\n" \
+        "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
+    fi
+  fi
+
   # Optional bootstrap
   # shellcheck disable=SC1090,SC2086
   [ -f "${BASHUNIT_BOOTSTRAP:-}" ] && source "$BASHUNIT_BOOTSTRAP" ${BASHUNIT_BOOTSTRAP_ARGS:-}
@@ -13757,7 +14862,8 @@ function bashunit::main::cmd_test() {
     # Disable coverage for assert mode - it's meant for running single assertions,
     # not tracking code coverage. This also prevents issues when parent bashunit
     # runs with coverage and calls subprocess bashunit with -a flag.
-    export BASHUNIT_COVERAGE=false
+    BASHUNIT_COVERAGE=false
+    export -n BASHUNIT_COVERAGE
     bashunit::main::exec_assert "$assert_fn" ${args+"${args[@]}"}
   else
     if [ "${BASHUNIT_WATCH_MODE:-false}" = true ]; then
@@ -13788,7 +14894,8 @@ function bashunit::main::cmd_bench() {
   local -a args=()
   local args_count=0
 
-  export BASHUNIT_BENCH_MODE=true
+  BASHUNIT_BENCH_MODE=true
+  export -n BASHUNIT_BENCH_MODE
 
   # Parse bench-specific options
   while [ $# -gt 0 ]; do
@@ -13798,17 +14905,20 @@ function bashunit::main::cmd_bench() {
       shift
       ;;
     -s | --simple)
-      export BASHUNIT_SIMPLE_OUTPUT=true
+      BASHUNIT_SIMPLE_OUTPUT=true
+      export -n BASHUNIT_SIMPLE_OUTPUT
       ;;
     --detailed)
-      export BASHUNIT_SIMPLE_OUTPUT=false
+      BASHUNIT_SIMPLE_OUTPUT=false
+      export -n BASHUNIT_SIMPLE_OUTPUT
       ;;
     -e | --env | --boot)
       # Support: --env "bootstrap.sh arg1 arg2"
       local boot_file="${2%% *}"
       local boot_args="${2#* }"
       if [ "$boot_args" != "$2" ]; then
-        export BASHUNIT_BOOTSTRAP_ARGS="$boot_args"
+        BASHUNIT_BOOTSTRAP_ARGS="$boot_args"
+        export -n BASHUNIT_BOOTSTRAP_ARGS
       fi
       # Export all variables from the env file so they're available in subshells
       # (e.g., process substitution used in load_test_files)
@@ -13819,13 +14929,16 @@ function bashunit::main::cmd_bench() {
       shift
       ;;
     -vvv | --verbose)
-      export BASHUNIT_VERBOSE=true
+      BASHUNIT_VERBOSE=true
+      export -n BASHUNIT_VERBOSE
       ;;
     --skip-env-file)
-      export BASHUNIT_SKIP_ENV_FILE=true
+      BASHUNIT_SKIP_ENV_FILE=true
+      export -n BASHUNIT_SKIP_ENV_FILE
       ;;
     -l | --login)
-      export BASHUNIT_LOGIN_SHELL=true
+      BASHUNIT_LOGIN_SHELL=true
+      export -n BASHUNIT_LOGIN_SHELL
       ;;
     --no-color)
       # shellcheck disable=SC2034
@@ -14151,6 +15264,10 @@ function bashunit::main::exec_tests() {
   trap 'bashunit::main::cleanup' SIGINT
   trap '[ $? -eq $EXIT_CODE_STOP_ON_FAILURE ] && bashunit::main::handle_stop_on_failure_sync' EXIT
 
+  # Resolve parallel mode once now that --parallel/--no-parallel are parsed, so
+  # the per-test is_enabled reads a global instead of re-checking env + OS.
+  bashunit::parallel::resolve_enabled
+
   if bashunit::env::is_parallel_run_enabled && ! bashunit::parallel::is_enabled; then
     printf "%sWarning: Parallel tests are supported on macOS, Ubuntu and Windows.\n" "${_BASHUNIT_COLOR_INCOMPLETE}"
     printf "For other OS (like Alpine), --parallel is not enabled due to inconsistent results,\n"
@@ -14172,7 +15289,8 @@ function bashunit::main::exec_tests() {
   # for replay and inherited by parallel test-file subshells.
   if bashunit::env::is_random_order_enabled; then
     if [ -z "${BASHUNIT_SEED:-}" ]; then
-      export BASHUNIT_SEED=$RANDOM
+      BASHUNIT_SEED=$RANDOM
+      export -n BASHUNIT_SEED
     fi
     if ! bashunit::env::is_tap_output_enabled; then
       bashunit::console_header::print_random_order_seed "$BASHUNIT_SEED"
@@ -14267,6 +15385,12 @@ function bashunit::main::exec_tests() {
     bashunit::parallel::cleanup
   fi
 
+  # Persist this run's failing tests so a later --rerun-failed can replay them.
+  bashunit::rerun::persist
+
+  # The rerun cache is read from the run dir above, so clean up only after it.
+  bashunit::env::cleanup_run_output_dir
+
   bashunit::internal_log "Finished tests" "exit_code:$exit_code"
   exit $exit_code
 }
@@ -14311,6 +15435,7 @@ function bashunit::main::cleanup() {
   if bashunit::parallel::is_enabled; then
     bashunit::parallel::cleanup
   fi
+  bashunit::env::cleanup_run_output_dir
   exit 1
 }
 
@@ -14328,6 +15453,7 @@ function bashunit::main::handle_stop_on_failure_sync() {
   if bashunit::parallel::is_enabled; then
     bashunit::parallel::cleanup
   fi
+  bashunit::env::cleanup_run_output_dir
   exit 1
 }
 
@@ -14521,7 +15647,7 @@ function _check_bash_version() {
 _check_bash_version
 
 # shellcheck disable=SC2034
-declare -r BASHUNIT_VERSION="0.41.0"
+declare -r BASHUNIT_VERSION="0.42.0"
 
 # shellcheck disable=SC2155
 declare -r BASHUNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
@@ -14535,10 +15661,13 @@ export BASHUNIT_WORKING_DIR
 for arg in "$@"; do
   case "$arg" in
   --skip-env-file)
-    export BASHUNIT_SKIP_ENV_FILE=true
+    # this-process-only (see the flag-parse loop in src/main.sh) (#837)
+    BASHUNIT_SKIP_ENV_FILE=true
+    export -n BASHUNIT_SKIP_ENV_FILE
     ;;
   -l | --login)
-    export BASHUNIT_LOGIN_SHELL=true
+    BASHUNIT_LOGIN_SHELL=true
+    export -n BASHUNIT_LOGIN_SHELL
     ;;
   --no-color)
     # shellcheck disable=SC2034


### PR DESCRIPTION
Update bashunit to version [0.42.0](https://github.com/TypedDevs/bashunit/releases/tag/0.42.0).

<details>
  <summary>Release Notes:</summary>

  
## 🐛 Bug Fixes
- A failing `set_up_before_script`/`set_up` now fails every test in the file with the hook's error, keeps the totals consistent, and lets the suite continue — a strict test file can no longer abort the whole run mid-suite (#836)
- Run-mode flags (`--parallel`, `--simple`, `--strict`, `--retry`, `--seed`, report paths, …) no longer leak through the environment into nested bashunit runs, so a script under test that calls bashunit gets default behavior; `BASHUNIT_*=…` configuration is unchanged (#834, #837)
- `install.sh` fails fast: a failed download, clone, build or copy aborts with a clear error instead of reporting success, and a failed beta clone no longer runs `build.sh` in the caller's directory (#840)
- `./build.sh --verify` exits non-zero when the built binary fails the suite, and the verification run no longer crashes mid-suite from tests resolving repo paths against the build folder (#834)
- `./bashunit bench` works again from a repository checkout (the dev entrypoint never sourced `src/benchmark.sh`) (#834)
- Snapshot placeholders (`::ignore::`) now work on systems without perl; multi-line placeholders still need perl (#823)
- Runs no longer leak a scratch directory under `$TMPDIR/bashunit/run/` — it is removed on exit, including `--version`/`--help`, subcommands and Ctrl-C (#811)
- `bashunit::helper::get_function_line_number` no longer disables `extdebug` for its caller (#808)
- `--test-timeout` no longer intermittently reports a fast test as timed out; the watchdog signals by pid and skips a test that already completed

## ✨ Improvements
- `watch` subcommand no longer fails when neither `inotifywait` nor `fswatch` is installed — it falls back to pure-shell polling (interval via `BASHUNIT_WATCH_INTERVAL`, default `2`s) instead of exiting (#779)
- Shell tab-completion scripts for bash and zsh under `completions/` (subcommands, `test` flags with value hints, assertion names), kept in sync by an anti-drift CI test (#778)
- `--rerun-failed` (`BASHUNIT_RERUN_FAILED`) replays only the previously failing tests, recorded in `.bashunit/last-failed`; composes with `--filter`/`--tag`/`--parallel` and falls back to the full suite when empty (add `.bashunit/` to `.gitignore`) (#776)
- Optional nightly `coverage.yml` workflow publishes a shields.io coverage badge from `--coverage` over the unit suite; schedule/manual only, never gates merges (#754)
- `--jobs auto` / `-j auto` caps parallel concurrency at the CPU core count (portable across Linux/macOS/BSD); the default stays unlimited (#766)

## 🛠️ Changes
- `build.sh` hardened: runs under `set -euo pipefail`, derives the embed list from the entrypoint's `source` order (single source of truth), guards against duplicate embeds and missing doc markers, drops `eval`, and gates every build behind `bash -n` (#834)
- `bashunit doc` no longer forks an `echo | sed` pipe per line of the assertion docs: a single awk pass prints the same bytes in ~50ms instead of ~5s (#832)
- Multi-file runs are no longer quadratic in file count; bashunit's own 63-file unit suite: ~64s -> ~22s sequential, ~26s -> ~7s parallel (#829)
- Major performance work with no behaviour change (near fork-free hot paths, cached snapshot/`--tag` scans, single-pass failure rendering). On bash 3.2: 100x10 `assert_equals` ~1.50s -> ~0.76s, 500 snapshot assertions ~7.5s -> ~3.0s, 100 tagged tests ~2.92s -> ~0.68s, acceptance suite ~61s -> ~17s (#761-#764, #772-#775, #798, #801-#807, #809, #810, #813, #817)
- Per-test timing now defaults to `auto` (`BASHUNIT_SHOW_EXECUTION_TIME=true|false|auto`): shown only when the clock is fork-free, avoiding `perl` forks on bash 3.2; `--profile`/`--verbose`/reports still measure (see `adrs/adr-008-auto-skip-per-test-timing.md`) (#765)
- `assert_equals`/`assert_same` failures with multiline values now render a git word-diff below the header (requires git, opt out with `BASHUNIT_NO_DIFF=true`, respects `--no-color`); machine reports keep the raw values (#777)


## 👥 Contributors
- @Chemaclass

## Checksum
SHA256: `a0e39761363d8b6876059cd5927cd4bed1b578be616c5490a8bf4102284a308c`

**Full Changelog:** [0.41.0...0.42.0](https://github.com/TypedDevs/bashunit/compare/0.41.0...0.42.0)
</details>