### PR TITLE
[BOT] Bump bashunit to version 0.43.0

### DIFF
--- a/lib/bashunit
+++ b/lib/bashunit
@@ -2221,6 +2221,23 @@ function bashunit::coverage::_branch_open_case_pattern() {
   case_in_pattern[idx]=1
 }
 
+# A loop (while/until/for/select) is a single-arm branch: its body. The arm is
+# taken iff the loop ran at least once (an executable body line was hit); a
+# never-taken body is an uncovered zero-iteration branch. Every `done`-closed
+# construct must push so `done` pairs with the right opener when nested.
+function bashunit::coverage::_branch_push_loop() {
+  local lineno=$1
+  loop_decision_line[loop_depth]=$lineno
+  loop_arm_start[loop_depth]=$((lineno + 1))
+  loop_depth=$((loop_depth + 1))
+}
+
+function bashunit::coverage::_branch_emit_loop() {
+  local lineno=$1 idx=$((loop_depth - 1))
+  echo "${loop_decision_line[$idx]}|loop|${loop_arm_start[$idx]}:$((lineno - 1))"
+  loop_depth=$idx
+}
+
 function bashunit::coverage::extract_branches() {
   local file="$1"
 
@@ -2239,6 +2256,8 @@ function bashunit::coverage::extract_branches() {
   local if_depth=0
   local -a case_decision_line=() case_arms=() case_arm_start=() case_in_pattern=()
   local case_depth=0
+  local -a loop_decision_line=() loop_arm_start=()
+  local loop_depth=0
 
   local lineno=0 line trimmed first
   while [ "$lineno" -lt "$total_lines" ]; do
@@ -2262,6 +2281,12 @@ function bashunit::coverage::extract_branches() {
     'case') bashunit::coverage::_branch_push_case "$lineno" ;;
     'esac')
       [ "$case_depth" -gt 0 ] && bashunit::coverage::_branch_emit_case "$lineno"
+      ;;
+    'while' | 'until' | 'for' | 'select')
+      bashunit::coverage::_branch_push_loop "$lineno"
+      ;;
+    'done')
+      [ "$loop_depth" -gt 0 ] && bashunit::coverage::_branch_emit_loop "$lineno"
       ;;
     *)
       [ "$case_depth" -eq 0 ] && continue
@@ -3746,16 +3771,6 @@ function bashunit::clock::total_runtime_in_milliseconds() {
   fi
 }
 
-function bashunit::clock::total_runtime_in_nanoseconds() {
-  local end_time
-  end_time=$(bashunit::clock::now)
-  if [ -n "$end_time" ]; then
-    bashunit::math::calculate "$end_time - $_BASHUNIT_START_TIME"
-  else
-    echo ""
-  fi
-}
-
 function bashunit::clock::init() {
   _BASHUNIT_START_TIME=$(bashunit::clock::now)
 }
@@ -3771,6 +3786,13 @@ case "$_bashunit_base64_help" in
 *) _BASHUNIT_BASE64_WRAP_FLAG=false ;;
 esac
 unset _bashunit_base64_help
+
+# Wire sentinel for an empty base64 payload. base64 of "" is "", which gets lost
+# in line parsing, so encode_base64 emits this token and both decode sites map it
+# back to "". Single source of truth keeps the encode (helpers.sh) and decode
+# (helpers.sh, runner.sh) sides byte-identical.
+# shellcheck disable=SC2034 # read cross-file in helpers.sh and runner.sh
+_BASHUNIT_BASE64_EMPTY_SENTINEL="_BASHUNIT_EMPTY_"
 
 _BASHUNIT_TESTS_PASSED=0
 _BASHUNIT_TESTS_FAILED=0
@@ -3910,16 +3932,8 @@ function bashunit::state::add_test_output() {
   _BASHUNIT_TEST_OUTPUT="$_BASHUNIT_TEST_OUTPUT$1"
 }
 
-function bashunit::state::get_test_exit_code() {
-  echo "$_BASHUNIT_TEST_EXIT_CODE"
-}
-
 function bashunit::state::set_test_exit_code() {
   _BASHUNIT_TEST_EXIT_CODE="$1"
-}
-
-function bashunit::state::get_test_title() {
-  echo "$_BASHUNIT_TEST_TITLE"
 }
 
 function bashunit::state::set_test_title() {
@@ -3930,10 +3944,6 @@ function bashunit::state::reset_test_title() {
   _BASHUNIT_TEST_TITLE=""
 }
 
-function bashunit::state::get_current_test_interpolated_function_name() {
-  echo "$_BASHUNIT_CURRENT_TEST_INTERPOLATED_NAME"
-}
-
 function bashunit::state::set_current_test_interpolated_function_name() {
   _BASHUNIT_CURRENT_TEST_INTERPOLATED_NAME="$1"
 }
@@ -3942,32 +3952,12 @@ function bashunit::state::reset_current_test_interpolated_function_name() {
   _BASHUNIT_CURRENT_TEST_INTERPOLATED_NAME=""
 }
 
-function bashunit::state::get_test_hook_failure() {
-  echo "$_BASHUNIT_TEST_HOOK_FAILURE"
-}
-
 function bashunit::state::set_test_hook_failure() {
   _BASHUNIT_TEST_HOOK_FAILURE="$1"
 }
 
-function bashunit::state::reset_test_hook_failure() {
-  _BASHUNIT_TEST_HOOK_FAILURE=""
-}
-
-function bashunit::state::get_test_hook_message() {
-  echo "$_BASHUNIT_TEST_HOOK_MESSAGE"
-}
-
 function bashunit::state::set_test_hook_message() {
   _BASHUNIT_TEST_HOOK_MESSAGE="$1"
-}
-
-function bashunit::state::reset_test_hook_message() {
-  _BASHUNIT_TEST_HOOK_MESSAGE=""
-}
-
-function bashunit::state::is_assertion_failed_in_test() {
-  ((_BASHUNIT_ASSERTION_FAILED_IN_TEST))
 }
 
 function bashunit::state::mark_assertion_failed_in_test() {
@@ -4698,29 +4688,13 @@ function bashunit::console_results::print_execution_time() {
   time="${time%%.*}"
   time="${time:-0}"
 
-  if [ "$time" -lt 1000 ]; then
-    printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
-      "Time taken: ${time}ms"
-    return
-  fi
-
-  local time_in_seconds=$((time / 1000))
-
-  if [ "$time_in_seconds" -ge 60 ]; then
-    local minutes=$((time_in_seconds / 60))
-    local seconds=$((time_in_seconds % 60))
-    printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
-      "Time taken: ${minutes}m ${seconds}s"
-    return
-  fi
-
-  local integer_part=$((time / 1000))
-  local decimal_part=$(( (time % 1000) / 10 ))
-  local formatted_seconds
-  formatted_seconds=$(printf "%d.%02d" "$integer_part" "$decimal_part")
+  # Reuse the shared ms formatter (Xm Ys / X.XXs / Xms) instead of re-deriving it;
+  # this runs once per run, so the command-substitution fork is negligible.
+  local formatted
+  formatted=$(bashunit::console_results::format_duration "$time")
 
   printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
-    "Time taken: ${formatted_seconds}s"
+    "Time taken: ${formatted}"
 }
 
 function bashunit::console_results::format_duration() {
@@ -5178,69 +5152,54 @@ function bashunit::console_results::print_profile_and_reset() {
   rm -f "$PROFILE_OUTPUT_PATH"
 }
 
+##
+# Flushes a deferred summary block (skipped/incomplete/risky): prints the
+# "There was 1 <noun>" / "There were N <nouns>" header, then the recorded lines
+# from output_path (carriage returns stripped, blank lines dropped, each prefixed
+# with "|"), removes the file and prints a trailing blank line. Callers own the
+# `[ -s path ]` (and any `is_show_*`) guard so each block keeps its own gate.
+# Arguments: $1 output path, $2 total count, $3 singular noun, $4 plural noun
+##
+function bashunit::console_results::flush_deferred_block() {
+  local output_path=$1
+  local total=$2
+  local singular=$3
+  local plural=$4
+
+  if bashunit::env::is_simple_output_enabled; then
+    printf "\n"
+  fi
+
+  if [ "$total" -eq 1 ]; then
+    echo -e "${_BASHUNIT_COLOR_BOLD}There was 1 ${singular}:${_BASHUNIT_COLOR_DEFAULT}\n"
+  else
+    echo -e "${_BASHUNIT_COLOR_BOLD}There were ${total} ${plural}:${_BASHUNIT_COLOR_DEFAULT}\n"
+  fi
+
+  tr -d '\r' <"$output_path" | sed '/^[[:space:]]*$/d' | sed 's/^/|/'
+  rm "$output_path"
+
+  echo ""
+}
+
 function bashunit::console_results::print_skipped_tests_and_reset() {
   if [ -s "$SKIPPED_OUTPUT_PATH" ] && bashunit::env::is_show_skipped_enabled; then
-    local total_skipped
-    total_skipped=$(bashunit::state::get_tests_skipped)
-
-    if bashunit::env::is_simple_output_enabled; then
-      printf "\n"
-    fi
-
-    if [ "$total_skipped" -eq 1 ]; then
-      echo -e "${_BASHUNIT_COLOR_BOLD}There was 1 skipped test:${_BASHUNIT_COLOR_DEFAULT}\n"
-    else
-      echo -e "${_BASHUNIT_COLOR_BOLD}There were $total_skipped skipped tests:${_BASHUNIT_COLOR_DEFAULT}\n"
-    fi
-
-    tr -d '\r' <"$SKIPPED_OUTPUT_PATH" | sed '/^[[:space:]]*$/d' | sed 's/^/|/'
-    rm "$SKIPPED_OUTPUT_PATH"
-
-    echo ""
+    bashunit::console_results::flush_deferred_block "$SKIPPED_OUTPUT_PATH" \
+      "$(bashunit::state::get_tests_skipped)" "skipped test" "skipped tests"
   fi
 }
 
 function bashunit::console_results::print_incomplete_tests_and_reset() {
   if [ -s "$INCOMPLETE_OUTPUT_PATH" ] && bashunit::env::is_show_incomplete_enabled; then
-    local total_incomplete
-    total_incomplete=$(bashunit::state::get_tests_incomplete)
-
-    if bashunit::env::is_simple_output_enabled; then
-      printf "\n"
-    fi
-
-    if [ "$total_incomplete" -eq 1 ]; then
-      echo -e "${_BASHUNIT_COLOR_BOLD}There was 1 incomplete test:${_BASHUNIT_COLOR_DEFAULT}\n"
-    else
-      echo -e "${_BASHUNIT_COLOR_BOLD}There were $total_incomplete incomplete tests:${_BASHUNIT_COLOR_DEFAULT}\n"
-    fi
-
-    tr -d '\r' <"$INCOMPLETE_OUTPUT_PATH" | sed '/^[[:space:]]*$/d' | sed 's/^/|/'
-    rm "$INCOMPLETE_OUTPUT_PATH"
-
-    echo ""
+    bashunit::console_results::flush_deferred_block "$INCOMPLETE_OUTPUT_PATH" \
+      "$(bashunit::state::get_tests_incomplete)" "incomplete test" "incomplete tests"
   fi
 }
 
 function bashunit::console_results::print_risky_tests_and_reset() {
   if [ -s "$RISKY_OUTPUT_PATH" ]; then
-    local total_risky
-    total_risky=$(bashunit::state::get_tests_risky)
-
-    if bashunit::env::is_simple_output_enabled; then
-      printf "\n"
-    fi
-
-    if [ "$total_risky" -eq 1 ]; then
-      echo -e "${_BASHUNIT_COLOR_BOLD}There was 1 risky test:${_BASHUNIT_COLOR_DEFAULT}\n"
-    else
-      echo -e "${_BASHUNIT_COLOR_BOLD}There were $total_risky risky tests:${_BASHUNIT_COLOR_DEFAULT}\n"
-    fi
-
-    tr -d '\r' <"$RISKY_OUTPUT_PATH" | sed '/^[[:space:]]*$/d' | sed 's/^/|/'
-    rm "$RISKY_OUTPUT_PATH"
-
-    echo ""
+    bashunit::console_results::flush_deferred_block "$RISKY_OUTPUT_PATH" \
+      "$(bashunit::state::get_tests_risky)" "risky test" "risky tests"
   fi
 }
 
@@ -5422,7 +5381,7 @@ function bashunit::helper::encode_base64() {
 
   # Handle empty string specially - base64 of "" is "", which gets lost in line parsing
   if [ -z "$value" ]; then
-    printf '%s' "_BASHUNIT_EMPTY_"
+    printf '%s' "$_BASHUNIT_BASE64_EMPTY_SENTINEL"
     return
   fi
 
@@ -5439,7 +5398,7 @@ function bashunit::helper::decode_base64() {
   local value="$1"
 
   # Empty input decodes to empty; short-circuit to skip the base64 fork (#762).
-  if [ -z "$value" ] || [ "$value" = "_BASHUNIT_EMPTY_" ]; then
+  if [ -z "$value" ] || [ "$value" = "$_BASHUNIT_BASE64_EMPTY_SENTINEL" ]; then
     printf ''
     return
   fi
@@ -5815,8 +5774,6 @@ function bashunit::helper::find_total_tests() {
         local -a functions_to_run=()
         # shellcheck disable=SC2206
         functions_to_run=($filtered_functions)
-        # shellcheck disable=SC2034
-        local -a provider_data=()
         local provider_data_count=0
         local fn_name line
         # Scan once; functions without a provider count as 1 with no fork (#763).
@@ -6103,23 +6060,6 @@ function bashunit::helper::tags_for_function() {
 }
 
 #
-# Extracts @tag annotations for a specific function from a test file.
-# Thin wrapper over the cached tags map, kept for callers that want the tags
-# on stdout. Hot-path call sites use build_tags_map + tags_for_function to
-# avoid the subshell fork.
-#
-# @param $1 string Function name
-# @param $2 string Script file path
-#
-# @return string Comma-separated list of tags, or empty if none
-#
-function bashunit::helper::get_tags_for_function() {
-  bashunit::helper::build_tags_map "$2"
-  bashunit::helper::tags_for_function "$1"
-  echo "$_BASHUNIT_TAGS_OUT"
-}
-
-#
 # Checks if a function's tags match the include/exclude filters.
 # Include uses OR logic (any match passes).
 # Exclude uses OR logic (any match fails).
@@ -6378,6 +6318,20 @@ function bashunit::assert::label_to_slot() {
   _BASHUNIT_ASSERT_LABEL_OUT=$_BASHUNIT_HELPER_NORMALIZED_OUT
 }
 
+_BASHUNIT_ASSERT_JOINED_OUT=""
+
+# Join positional args into _BASHUNIT_ASSERT_JOINED_OUT with no fork.
+# Output matches $(printf '%s\n' "$@") exactly: newline-joined, trailing
+# newlines stripped (as command substitution strips them).
+function bashunit::assert::join_to_slot() {
+  local IFS=$'\n'
+  local joined="$*"
+  while [ "$joined" != "${joined%$'\n'}" ]; do
+    joined="${joined%$'\n'}"
+  done
+  _BASHUNIT_ASSERT_JOINED_OUT=$joined
+}
+
 # Resolve assertion label: use custom label if provided, otherwise derive from test function name
 function bashunit::assert::label() {
   bashunit::assert::label_to_slot "${1:-}"
@@ -6623,8 +6577,8 @@ function assert_contains() {
   local -a actual_arr
   actual_arr=("${@:2}")
   local label_override=""
-  local actual
-  actual=$(printf '%s\n' "${actual_arr[@]}")
+  bashunit::assert::join_to_slot "${actual_arr[@]}"
+  local actual=$_BASHUNIT_ASSERT_JOINED_OUT
 
   case "$actual" in
   *"$expected"*) ;;
@@ -6676,8 +6630,8 @@ function assert_not_contains() {
   local expected="$1"
   local -a actual_arr
   actual_arr=("${@:2}")
-  local actual
-  actual=$(printf '%s\n' "${actual_arr[@]}")
+  bashunit::assert::join_to_slot "${actual_arr[@]}"
+  local actual=$_BASHUNIT_ASSERT_JOINED_OUT
 
   case "$actual" in
   *"$expected"*)
@@ -6699,8 +6653,8 @@ function assert_matches() {
   local expected="$1"
   local -a actual_arr
   actual_arr=("${@:2}")
-  local actual
-  actual=$(printf '%s\n' "${actual_arr[@]}")
+  bashunit::assert::join_to_slot "${actual_arr[@]}"
+  local actual=$_BASHUNIT_ASSERT_JOINED_OUT
 
   if [ "$(printf '%s' "$actual" | "$GREP" -cE "$expected" || true)" -eq 0 ]; then
     # Retry with newlines collapsed for cross-line patterns
@@ -6725,8 +6679,8 @@ function assert_not_matches() {
   local expected="$1"
   local -a actual_arr
   actual_arr=("${@:2}")
-  local actual
-  actual=$(printf '%s\n' "${actual_arr[@]}")
+  bashunit::assert::join_to_slot "${actual_arr[@]}"
+  local actual=$_BASHUNIT_ASSERT_JOINED_OUT
 
   # Check both line-by-line and with newlines collapsed for cross-line patterns
   if [ "$(printf '%s' "$actual" | "$GREP" -cE "$expected" || true)" -gt 0 ] ||
@@ -7002,8 +6956,8 @@ function assert_string_starts_with() {
   local expected="$1"
   local -a actual_arr
   actual_arr=("${@:2}")
-  local actual
-  actual=$(printf '%s\n' "${actual_arr[@]}")
+  bashunit::assert::join_to_slot "${actual_arr[@]}"
+  local actual=$_BASHUNIT_ASSERT_JOINED_OUT
 
   case "$actual" in
   "$expected"*) ;;
@@ -7047,8 +7001,8 @@ function assert_string_ends_with() {
   local expected="$1"
   local -a actual_arr
   actual_arr=("${@:2}")
-  local actual
-  actual=$(printf '%s\n' "${actual_arr[@]}")
+  bashunit::assert::join_to_slot "${actual_arr[@]}"
+  local actual=$_BASHUNIT_ASSERT_JOINED_OUT
 
   case "$actual" in
   *"$expected") ;;
@@ -7072,8 +7026,8 @@ function assert_string_not_ends_with() {
   local expected="$1"
   local -a actual_arr
   actual_arr=("${@:2}")
-  local actual
-  actual=$(printf '%s\n' "${actual_arr[@]}")
+  bashunit::assert::join_to_slot "${actual_arr[@]}"
+  local actual=$_BASHUNIT_ASSERT_JOINED_OUT
 
   case "$actual" in
   *"$expected")
@@ -7401,10 +7355,8 @@ function assert_array_contains() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+  bashunit::assert::label_to_slot
+  local label=$_BASHUNIT_ASSERT_LABEL_OUT
   shift
 
   local -a actual
@@ -7427,10 +7379,8 @@ function assert_array_length() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+  bashunit::assert::label_to_slot
+  local label=$_BASHUNIT_ASSERT_LABEL_OUT
   shift
 
   # Use $# / $* rather than building an array: on Bash 3.0 under `set -u`,
@@ -7451,10 +7401,8 @@ function assert_array_not_contains() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+  bashunit::assert::label_to_slot
+  local label=$_BASHUNIT_ASSERT_LABEL_OUT
   shift
   local -a actual
   actual=("$@")
@@ -7577,10 +7525,8 @@ function assert_date_equals() {
   actual="$(bashunit::date::to_epoch "$2")"
 
   if [ "$actual" -ne "$expected" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be equal to" "${expected}"
     return
@@ -7598,10 +7544,8 @@ function assert_date_before() {
   actual="$(bashunit::date::to_epoch "$2")"
 
   if [ "$actual" -ge "$expected" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be before" "${expected}"
     return
@@ -7619,10 +7563,8 @@ function assert_date_after() {
   actual="$(bashunit::date::to_epoch "$2")"
 
   if [ "$actual" -le "$expected" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be after" "${expected}"
     return
@@ -7642,10 +7584,8 @@ function assert_date_within_range() {
   actual="$(bashunit::date::to_epoch "$3")"
 
   if [ "$actual" -lt "$from" ] || [ "$actual" -gt "$to" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be between" "${from} and ${to}"
     return
@@ -7669,10 +7609,8 @@ function assert_date_within_delta() {
   fi
 
   if [ "$diff" -gt "$delta" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${actual}" "to be within" "${delta} seconds of ${expected}"
     return
@@ -7710,10 +7648,8 @@ function assert_duration() {
   elapsed_ms=$(bashunit::duration::measure_ms "$command")
 
   if [ "$elapsed_ms" -gt "$threshold_ms" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${threshold_ms}" "to complete within (ms)" "${command}"
     return
@@ -7732,10 +7668,8 @@ function assert_duration_less_than() {
   elapsed_ms=$(bashunit::duration::measure_ms "$command")
 
   if [ "$elapsed_ms" -ge "$threshold_ms" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${threshold_ms}" "to complete within (ms)" "${command}"
     return
@@ -7754,10 +7688,8 @@ function assert_duration_greater_than() {
   elapsed_ms=$(bashunit::duration::measure_ms "$command")
 
   if [ "$elapsed_ms" -le "$threshold_ms" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${threshold_ms}" "to take at least (ms)" "${command}"
     return
@@ -7772,11 +7704,10 @@ function assert_file_exists() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${3:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -f "$expected" ]; then
+    bashunit::assert::label_to_slot "${3:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to exist but" "do not exist"
     return
@@ -7789,11 +7720,10 @@ function assert_file_not_exists() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${3:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ -f "$expected" ]; then
+    bashunit::assert::label_to_slot "${3:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to not exist but" "the file exists"
     return
@@ -7806,11 +7736,10 @@ function assert_is_file() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${3:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -f "$expected" ]; then
+    bashunit::assert::label_to_slot "${3:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be a file" "but is not a file"
     return
@@ -7823,11 +7752,10 @@ function assert_is_file_empty() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${3:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ -s "$expected" ]; then
+    bashunit::assert::label_to_slot "${3:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be empty" "but is not empty"
     return
@@ -7843,10 +7771,8 @@ function assert_files_equals() {
   local actual="$2"
 
   if [ "$(diff -u "$expected" "$actual")" != '' ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
 
     bashunit::console_results::print_failed_test "${label}" "${expected}" "Compared" "${actual}" \
@@ -7864,10 +7790,8 @@ function assert_files_not_equals() {
   local actual="$2"
 
   if [ "$(diff -u "$expected" "$actual")" = '' ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
 
     bashunit::console_results::print_failed_test "${label}" "${expected}" "Compared" "${actual}" \
@@ -7885,10 +7809,8 @@ function assert_file_contains() {
   local string="$2"
 
   if ! grep -F -q "$string" "$file"; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
 
     bashunit::console_results::print_failed_test "${label}" "${file}" "to contain" "${string}"
@@ -7905,10 +7827,8 @@ function assert_file_not_contains() {
   local string="$2"
 
   if grep -q "$string" "$file"; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
 
     bashunit::console_results::print_failed_test "${label}" "${file}" "to not contain" "${string}"
@@ -7940,10 +7860,8 @@ function assert_file_permissions() {
 
   local expected="$1"
   local file="$2"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+  bashunit::assert::label_to_slot
+  local label=$_BASHUNIT_ASSERT_LABEL_OUT
 
   if [ ! -e "$file" ]; then
     bashunit::assert::mark_failed
@@ -7975,11 +7893,10 @@ function assert_directory_exists() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to exist but" "do not exist"
     return
@@ -7992,11 +7909,10 @@ function assert_directory_not_exists() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ -d "$expected" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to not exist but" "the directory exists"
     return
@@ -8009,11 +7925,10 @@ function assert_is_directory() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be a directory" "but is not a directory"
     return
@@ -8026,11 +7941,10 @@ function assert_is_directory_empty() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ] || [ -n "$(ls -A "$expected")" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be empty" "but is not empty"
     return
@@ -8043,11 +7957,10 @@ function assert_is_directory_not_empty() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ] || [ -z "$(ls -A "$expected")" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to not be empty" "but is empty"
     return
@@ -8060,11 +7973,10 @@ function assert_is_directory_readable() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ] || [ ! -r "$expected" ] || [ ! -x "$expected" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be readable" "but is not readable"
     return
@@ -8077,11 +7989,10 @@ function assert_is_directory_not_readable() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ] || { [ -r "$expected" ] && [ -x "$expected" ]; }; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be not readable" "but is readable"
     return
@@ -8094,11 +8005,10 @@ function assert_is_directory_writable() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ] || [ ! -w "$expected" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be writable" "but is not writable"
     return
@@ -8111,11 +8021,10 @@ function assert_is_directory_not_writable() {
   bashunit::assert::should_skip && return 0
 
   local expected="$1"
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label="${2:-$(bashunit::helper::normalize_test_function_name "$test_fn")}"
 
   if [ ! -d "$expected" ] || [ -w "$expected" ]; then
+    bashunit::assert::label_to_slot "${2:-}"
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "to be not writable" "but is writable"
     return
@@ -8143,10 +8052,8 @@ function assert_json_key_exists() {
 
   local result
   if ! result=$(printf '%s' "$json" | jq -e "$key" 2>/dev/null) || [ "$result" = "null" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${json}" "to have key" "${key}"
     return
@@ -8165,20 +8072,16 @@ function assert_json_contains() {
 
   local result
   if ! result=$(printf '%s' "$json" | jq -e -r "$key" 2>/dev/null) || [ "$result" = "null" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${json}" "to have key" "${key}"
     return
   fi
 
   if [ "$result" != "$expected" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "but got " "${result}"
     return
@@ -8200,10 +8103,8 @@ function assert_json_equals() {
   actual_sorted=$(printf '%s' "$actual" | jq -S '.' 2>/dev/null)
 
   if [ "$expected_sorted" != "$actual_sorted" ]; then
-    local test_fn
-    test_fn="$(bashunit::helper::find_test_function_name)"
-    local label
-    label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+    bashunit::assert::label_to_slot
+    local label=$_BASHUNIT_ASSERT_LABEL_OUT
     bashunit::assert::mark_failed
     bashunit::console_results::print_failed_test "${label}" "${expected}" "but got " "${actual}"
     return
@@ -9718,6 +9619,25 @@ function test_failure() {
 ```
 :::
 
+## assert_not_equals
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
+
+- [assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_equals "foo" "bar"
+}
+
+function test_failure() {
+  assert_not_equals "foo" "foo"
+}
+```
+:::
+
 ## assert_not_same
 > `assert_not_same "expected" "actual"`
 
@@ -10943,6 +10863,11 @@ _BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT=0
 _BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT=0
 _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT=""
 _BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT=""
+# Per-suite ordinal for naming a parallel worker's `.result` file. Set by
+# call_test_functions (single-threaded dispatch) just before each backgrounded
+# run_test; the fork inherits the value, so every test in a file gets a unique,
+# collision-free name in its per-suite dir without forking mktemp/mv.
+_BASHUNIT_RUNNER_RESULT_ORDINAL=0
 # Suffix appended to a passed-test line when it only passed after retrying.
 _BASHUNIT_RETRY_NOTE=""
 
@@ -11649,6 +11574,8 @@ function bashunit::runner::call_test_functions() {
   local provider_data_count=0
   local -a parsed_data=()
   local parsed_data_count=0
+  # Monotonic within this file; names each parallel worker's .result file.
+  local _test_ordinal=0
 
   # Scan the file once; per-test provider lookups below are pure-bash (#763).
   # The same pass also detects the no-parallel-tests opt-out (#774).
@@ -11677,6 +11604,8 @@ function bashunit::runner::call_test_functions() {
     if [ -z "$_BASHUNIT_PROVIDER_FN_OUT" ]; then
       if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
         bashunit::runner::wait_for_job_slot
+        _test_ordinal=$((_test_ordinal + 1))
+        _BASHUNIT_RUNNER_RESULT_ORDINAL=$_test_ordinal
         bashunit::runner::run_test "$script" "$fn_name" &
       else
         bashunit::runner::run_test "$script" "$fn_name"
@@ -11707,6 +11636,8 @@ function bashunit::runner::call_test_functions() {
       done <<<"$(bashunit::runner::parse_data_provider_args "$data")"
       if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
         bashunit::runner::wait_for_job_slot
+        _test_ordinal=$((_test_ordinal + 1))
+        _BASHUNIT_RUNNER_RESULT_ORDINAL=$_test_ordinal
         bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"} &
       else
         bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"}
@@ -12285,7 +12216,7 @@ function bashunit::runner::decode_subshell_output() {
 
   local test_output_base64="${test_execution_result##*##TEST_OUTPUT=}"
   test_output_base64="${test_output_base64%%##*}"
-  if [ -z "$test_output_base64" ] || [ "$test_output_base64" = "_BASHUNIT_EMPTY_" ]; then
+  if [ -z "$test_output_base64" ] || [ "$test_output_base64" = "$_BASHUNIT_BASE64_EMPTY_SENTINEL" ]; then
     _BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT=""
     return
   fi
@@ -12384,39 +12315,16 @@ function bashunit::runner::parse_result_parallel() {
   local fn_name=$1
   shift
   local execution_result=$1
-  shift
-  local IFS=$' \t\n'
-  local -a args
-  args=("$@")
-
   # This runs once per test in every parallel worker, so avoid per-test forks:
   # derive the suite dir name with parameter expansion (no basename), only
   # mkdir when the dir is missing (first test of the file wins the race,
-  # `-p` makes the losers no-ops), and skip arg sanitizing entirely for the
-  # common no-provider-args case.
+  # `-p` makes the losers no-ops), and name the result file by the per-suite
+  # ordinal the dispatcher assigned — unique without forking mktemp or mv.
   local test_suite_base="${test_file##*/}"
   local test_suite_dir="${TEMP_DIR_PARALLEL_TEST_SUITE}/${test_suite_base%.sh}"
   [ -d "$test_suite_dir" ] || mkdir -p "$test_suite_dir"
 
-  local sanitized_args=""
-  if [ -n "${args[*]+"${args[*]}"}" ]; then
-    sanitized_args=$(echo "${args[*]}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//')
-  fi
-  local template
-  if [ -z "$sanitized_args" ]; then
-    template="${fn_name}.XXXXXX"
-  else
-    template="${fn_name}-${sanitized_args}.XXXXXX"
-  fi
-
-  local unique_test_result_file
-  if unique_test_result_file=$("$MKTEMP" -p "$test_suite_dir" "$template" 2>/dev/null); then
-    true
-  else
-    unique_test_result_file=$("$MKTEMP" "$test_suite_dir/$template")
-  fi
-  mv "$unique_test_result_file" "${unique_test_result_file}.result"
-  unique_test_result_file="${unique_test_result_file}.result"
+  local unique_test_result_file="${test_suite_dir}/${_BASHUNIT_RUNNER_RESULT_ORDINAL}.result"
 
   bashunit::internal_log "[PARA]" "fn_name:$fn_name" "execution_result:$execution_result"
 
@@ -13121,10 +13029,8 @@ function bashunit::assertion_failed() {
   local actual=$2
   local failure_condition_message=${3:-"but got "}
 
-  local test_fn
-  test_fn="$(bashunit::helper::find_test_function_name)"
-  local label
-  label="$(bashunit::helper::normalize_test_function_name "$test_fn")"
+  bashunit::assert::label_to_slot
+  local label=$_BASHUNIT_ASSERT_LABEL_OUT
   bashunit::assert::mark_failed
   bashunit::console_results::print_failed_test "${label}" "${expected}" \
     "$failure_condition_message" "${actual}"
@@ -15647,7 +15553,7 @@ function _check_bash_version() {
 _check_bash_version
 
 # shellcheck disable=SC2034
-declare -r BASHUNIT_VERSION="0.42.0"
+declare -r BASHUNIT_VERSION="0.43.0"
 
 # shellcheck disable=SC2155
 declare -r BASHUNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
Update bashunit to version [0.43.0](https://github.com/TypedDevs/bashunit/releases/tag/0.43.0).

<details>
  <summary>Release Notes:</summary>

  
## ✨ Improvements
- Branch coverage now reports loop constructs (`while`/`until`/`for`/`select`): the loop body is a single-arm branch, marked covered only when the loop ran at least once, so a never-entered zero-iteration loop surfaces as an uncovered branch (#855)

## 🛠️ Changes
- Core string assertions (`assert_contains`/`assert_not_contains`, `assert_matches`/`assert_not_matches`, `assert_string_starts_with`/`assert_string_ends_with` and their negations) no longer fork a subshell per call to join their arguments; a fork-free join with identical behaviour replaces it (#844)
- The array, date, duration, json, files and folders assertions now resolve their failure label through the fork-free slot helper instead of a per-call command substitution — same labels, fewer forks
- Parallel test workers name their per-test result file by a per-suite ordinal instead of `mktemp` + `mv`, removing two forks per test (plus the `echo \| tr \| sed` arg sanitizing for data-provider tests) with identical result aggregation (#851)


## 👥 Contributors
- @Chemaclass

## Checksum
SHA256: `151f3647964d53d3f5a7065c141790fc1b66ea3039024c80ed09b3a9602064a2`

**Full Changelog:** [0.42.0...0.43.0](https://github.com/TypedDevs/bashunit/compare/0.42.0...0.43.0)
</details>